### PR TITLE
Test case for "composes" classes

### DIFF
--- a/test/cases/composes-async/async-1.css
+++ b/test/cases/composes-async/async-1.css
@@ -1,0 +1,4 @@
+:local .base {
+  composes: composed from './async-2.css';
+  background: blue;
+}

--- a/test/cases/composes-async/async-2.css
+++ b/test/cases/composes-async/async-2.css
@@ -1,0 +1,3 @@
+:local .composed {
+  background: green;
+}

--- a/test/cases/composes-async/expected/1.css
+++ b/test/cases/composes-async/expected/1.css
@@ -1,0 +1,4 @@
+.base {
+  background: blue;
+}
+

--- a/test/cases/composes-async/expected/2.css
+++ b/test/cases/composes-async/expected/2.css
@@ -1,0 +1,4 @@
+.composed {
+  background: green;
+}
+

--- a/test/cases/composes-async/index.js
+++ b/test/cases/composes-async/index.js
@@ -1,0 +1,2 @@
+import('./async-1.css');
+import('./async-2.css');

--- a/test/cases/composes-async/webpack.config.js
+++ b/test/cases/composes-async/webpack.config.js
@@ -1,0 +1,26 @@
+const Self = require('../../../');
+
+module.exports = {
+  entry: './index.js',
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          Self.loader,
+          {
+            loader: 'css-loader',
+            options: {
+              localIdentName: '[local]'
+            }
+          }
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new Self({
+      filename: '[name].css',
+    }),
+  ],
+};


### PR DESCRIPTION
It seems that if you compose to a different class it will import the entire css twice.

### Input

async-1.css
```css
:local .base {
  composes: composed from './async-2.css';
  background: blue;
}
```

async-2.css
```css
:local .composed {
  background: green;
}
```

### Desired output

1.css
```css
.base {
  background: blue;
}
```

2.css
```css
.composed {
  background: green;
}
```

### Current output

1.css
```css
.composed {
  background: green;
}

.base {
  background: blue;
}
```

2.css
```css
.composed {
  background: green;
}
```