### PR TITLE
fix(index): Use the runtime publicPath when generating the href

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,7 @@ class MiniCssExtractPlugin {
                   'linkTag.rel = "stylesheet";',
                   'linkTag.onload = resolve;',
                   'linkTag.onerror = reject;',
-                  `linkTag.href = ${linkHrefPath};`,
+                  `linkTag.href = ${mainTemplate.requireFn}.p + ${linkHrefPath};`,
                   'var head = document.getElementsByTagName("head")[0];',
                   'head.appendChild(linkTag);',
                 ]),


### PR DESCRIPTION
Right now all generated URLs end up being top level URLs.

Fixes https://github.com/webpack-contrib/mini-css-extract-plugin/issues/2