### PR TITLE
Do not match .ass

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.s?[ac]ss$/,
+        test: /\.(sa|sc|c)ss$/,
         use: [
           devMode ? 'style-loader' : MiniCssExtractPlugin.loader,
           'css-loader',


### PR DESCRIPTION
Use a capturing group to match only exactly `.sass`, `.scss`, and `.css`.
