### PR TITLE
Move webpack from devDeps to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@webpack-contrib/schema-utils": "^1.0.0-beta.0",
     "loader-utils": "^1.1.0",
+    "webpack": "^4.4.0",
     "webpack-sources": "^1.1.0"
   },
   "devDependencies": {
@@ -72,7 +73,6 @@
     "pre-commit": "^1.2.2",
     "prettier": "^1.11.1",
     "standard-version": "^4.3.0",
-    "webpack": "^4.4.0",
     "webpack-cli": "^2.0.13",
     "webpack-defaults": "^2.3.0",
     "webpack-dev-server": "^3.1.1"


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Actually, `webpack` has been imported in https://github.com/webpack-contrib/mini-css-extract-plugin/blob/41347f72aaf5927a4faacce5e0f43e90126b0c17/src/index.js#L4

It may cause some deps error in some particular `npm install` cases imo.

Thanks.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info