### PR TITLE
refactor: replace literal plugin name in strings with const

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -175,7 +175,7 @@ class MiniCssExtractPlugin {
                 chunk,
                 contentHashType: NS,
               },
-              identifier: `mini-css-extract-plugin.${chunk.id}`,
+              identifier: `${pluginName}.${chunk.id}`,
               hash: chunk.contentHash[NS],
             });
           }
@@ -199,7 +199,7 @@ class MiniCssExtractPlugin {
                 chunk,
                 contentHashType: NS,
               },
-              identifier: `mini-css-extract-plugin.${chunk.id}`,
+              identifier: `${pluginName}.${chunk.id}`,
               hash: chunk.contentHash[NS],
             });
           }
@@ -312,7 +312,7 @@ class MiniCssExtractPlugin {
             return Template.asString([
               source,
               '',
-              '// mini-css-extract-plugin CSS loading',
+              `// ${pluginName} CSS loading`,
               `var cssChunks = ${JSON.stringify(chunkMap)};`,
               'if(installedCssChunks[chunkId]) promises.push(installedCssChunks[chunkId]);',
               'else if(installedCssChunks[chunkId] !== 0 && cssChunks[chunkId]) {',


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Use const instead of repeat literal strings.

### Breaking Changes

None.
