### PR TITLE
fix(loader): pass `emitFile` to the child compilation (`loaderContext.emitFile`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,7 @@ class MiniCssExtractPlugin {
       compilation.hooks.normalModuleLoader.tap(pluginName, (lc, m) => {
         const loaderContext = lc;
         const module = m;
-        loaderContext[MODULE_TYPE] = (content, assets) => {
+        loaderContext[MODULE_TYPE] = (content) => {
           if (!Array.isArray(content) && content != null) {
             throw new Error(
               `Exported value was not extracted as an array: ${JSON.stringify(
@@ -146,12 +146,6 @@ class MiniCssExtractPlugin {
               )}`
             );
           }
-
-          module.buildInfo = module.buildInfo || {};
-          module.buildInfo.assets = {
-            ...module.buildInfo.assets,
-            ...assets,
-          };
 
           const identifierCountMap = new Map();
           for (const line of content) {

--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,7 @@ class MiniCssExtractPlugin {
       compilation.hooks.normalModuleLoader.tap(pluginName, (lc, m) => {
         const loaderContext = lc;
         const module = m;
-        loaderContext[MODULE_TYPE] = (content) => {
+        loaderContext[MODULE_TYPE] = (content, assets) => {
           if (!Array.isArray(content) && content != null) {
             throw new Error(
               `Exported value was not extracted as an array: ${JSON.stringify(
@@ -146,6 +146,13 @@ class MiniCssExtractPlugin {
               )}`
             );
           }
+
+          module.buildInfo = module.buildInfo || { assets: {} };
+          module.buildInfo.assets = {
+            ...module.buildInfo.assets,
+            ...assets,
+          };
+
           const identifierCountMap = new Map();
           for (const line of content) {
             const count = identifierCountMap.get(line.identifier) || 0;

--- a/src/index.js
+++ b/src/index.js
@@ -147,7 +147,7 @@ class MiniCssExtractPlugin {
             );
           }
 
-          module.buildInfo = module.buildInfo || { assets: {} };
+          module.buildInfo = module.buildInfo || {};
           module.buildInfo.assets = {
             ...module.buildInfo.assets,
             ...assets,

--- a/src/loader.js
+++ b/src/loader.js
@@ -76,10 +76,18 @@ export function pitch(request) {
   );
 
   let source;
+  let assets = {};
   childCompiler.hooks.afterCompile.tap(pluginName, (compilation) => {
     source =
       compilation.assets[childFilename] &&
       compilation.assets[childFilename].source();
+
+    // Collect assets from modules
+    compilation.modules.forEach((module) => {
+      if (module.buildInfo && module.buildInfo.assets) {
+        assets = { ...assets, ...module.buildInfo.assets };
+      }
+    });
 
     // Remove all chunk assets
     compilation.chunks.forEach((chunk) => {
@@ -123,7 +131,7 @@ export function pitch(request) {
           };
         });
       }
-      this[MODULE_TYPE](text);
+      this[MODULE_TYPE](text, assets);
     } catch (e) {
       return callback(e);
     }

--- a/src/loader.js
+++ b/src/loader.js
@@ -59,6 +59,7 @@ export function pitch(request) {
       compilation.hooks.normalModuleLoader.tap(
         `${pluginName} loader`,
         (loaderContext, module) => {
+          loaderContext.emitFile = this.emitFile;
           loaderContext[MODULE_TYPE] = false; // eslint-disable-line no-param-reassign
           if (module.request === request) {
             // eslint-disable-next-line no-param-reassign
@@ -76,18 +77,10 @@ export function pitch(request) {
   );
 
   let source;
-  const assets = {};
   childCompiler.hooks.afterCompile.tap(pluginName, (compilation) => {
     source =
       compilation.assets[childFilename] &&
       compilation.assets[childFilename].source();
-
-    // Collect assets from modules
-    compilation.modules.forEach((module) => {
-      if (module.buildInfo && module.buildInfo.assets) {
-        Object.assign(assets, module.buildInfo.assets);
-      }
-    });
 
     // Remove all chunk assets
     compilation.chunks.forEach((chunk) => {
@@ -131,7 +124,7 @@ export function pitch(request) {
           };
         });
       }
-      this[MODULE_TYPE](text, assets);
+      this[MODULE_TYPE](text);
     } catch (e) {
       return callback(e);
     }

--- a/src/loader.js
+++ b/src/loader.js
@@ -76,7 +76,7 @@ export function pitch(request) {
   );
 
   let source;
-  let assets = {};
+  const assets = {};
   childCompiler.hooks.afterCompile.tap(pluginName, (compilation) => {
     source =
       compilation.assets[childFilename] &&
@@ -85,7 +85,7 @@ export function pitch(request) {
     // Collect assets from modules
     compilation.modules.forEach((module) => {
       if (module.buildInfo && module.buildInfo.assets) {
-        assets = { ...assets, ...module.buildInfo.assets };
+        Object.assign(assets, module.buildInfo.assets);
       }
     });
 

--- a/test/TestMemoryFS.test.js
+++ b/test/TestMemoryFS.test.js
@@ -1,0 +1,39 @@
+import path from 'path';
+
+import MemoryFS from 'memory-fs';
+import webpack from 'webpack';
+
+const assetsNames = (json) => json.assets.map((asset) => asset.name);
+
+describe('TestMemoryFS', () => {
+  it('should preserve asset even if not emitted', (done) => {
+    const casesDirectory = path.resolve(__dirname, 'cases');
+    const directoryForCase = path.resolve(casesDirectory, 'simple-publicpath');
+    const webpackConfig = require(path.resolve(
+      directoryForCase,
+      'webpack.config.js'
+    ));
+    const compiler = webpack({
+      ...webpackConfig,
+      mode: 'development',
+      context: directoryForCase,
+    });
+    compiler.outputFileSystem = new MemoryFS();
+    compiler.run((err1, stats1) => {
+      if (err1) {
+        done(err1);
+        return;
+      }
+      compiler.run((err2, stats2) => {
+        if (err2) {
+          done(err2);
+          return;
+        }
+        expect(assetsNames(stats1.toJson())).toEqual(
+          assetsNames(stats2.toJson())
+        );
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Looks like `mini-css-extract-plugin` when collecting sources it's replacing module dependencies
with new `CssDependency` as assets are loaded before. IMHO we can collect and add it back to updated module. 

Use-case for this is when using `hard-source-plugin` and reading from cache can't find asset 
https://github.com/mzgoddard/hard-source-webpack-plugin/issues/367

### Breaking Changes

No breaking changes, all current test's are passing

### Additional Info
