### PR TITLE
build(babel): use same node version as declared in package.json

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
       {
         "useBuiltIns": true,
         "targets": {
-          "node": "6.11.5"
+          "node": "6.9.0"
         },
         "exclude": [
           "transform-async-to-generator",


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Babel should have Node target version set to minimal required version declared in `package.json`.

It seems like `.babelrc` has been missed during #82 refactor.