### PR TITLE
docs(readme): move long term caching guide from errant section

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ module.exports = {
 }
 ```
 
+#### Long Term Caching
+
+For long term caching use `filename: "[contenthash].css"`. Optionally add `[name]`.
+
 <h2 align="center">Maintainers</h2>
 
 <table>
@@ -283,10 +287,6 @@ module.exports = {
     </tr>
   <tbody>
 </table>
-
-#### Long Term Caching
-
-For long term caching use `filename: "[contenthash].css"`. Optionally add `[name]`.
 
 
 ## License


### PR DESCRIPTION
Move the _Long Term Caching_ feature outside of the _Maintainers_ section so it's easier to see.

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update**
- [ ] **typo fix**
- [ ] **metadata update**
- [x] **documentation fix**

### Motivation / Use-Case
This minor change improves the legibility of the README.

### Additional Info
N/A