### PR TITLE
Fix order of css import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -387,10 +387,12 @@ class MiniCssExtractPlugin {
     // with different order this can lead to wrong order
     // but it's not possible to create a correct order in
     // this case. Don't share chunks if you don't like it.
+
+
     const [chunkGroup] = chunk.groupsIterable;
     if (typeof chunkGroup.getModuleIndex2 === 'function') {
       modules.sort(
-        (a, b) => chunkGroup.getModuleIndex2(a) - chunkGroup.getModuleIndex2(b)
+        (a, b) => (chunkGroup.getModuleIndex2(a) || 0) < (chunkGroup.getModuleIndex2(b) || 0) ? 1 : -1
       );
     } else {
       // fallback for older webpack versions

--- a/src/index.js
+++ b/src/index.js
@@ -387,8 +387,6 @@ class MiniCssExtractPlugin {
     // with different order this can lead to wrong order
     // but it's not possible to create a correct order in
     // this case. Don't share chunks if you don't like it.
-
-
     const [chunkGroup] = chunk.groupsIterable;
     if (typeof chunkGroup.getModuleIndex2 === 'function') {
       modules.sort(

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,10 @@ import webpack from 'webpack';
 import sources from 'webpack-sources';
 
 const { ConcatSource, SourceMapSource, OriginalSource } = sources;
-const { Template, util: { createHash } } = webpack;
+const {
+  Template,
+  util: { createHash },
+} = webpack;
 
 const NS = path.dirname(fs.realpathSync(__filename));
 
@@ -97,7 +100,12 @@ class CssModule extends webpack.Module {
 }
 
 class CssModuleFactory {
-  create({ dependencies: [dependency] }, callback) {
+  create(
+    {
+      dependencies: [dependency],
+    },
+    callback
+  ) {
     callback(null, new CssModule(dependency));
   }
 }
@@ -390,7 +398,11 @@ class MiniCssExtractPlugin {
     const [chunkGroup] = chunk.groupsIterable;
     if (typeof chunkGroup.getModuleIndex2 === 'function') {
       modules.sort(
-        (a, b) => (chunkGroup.getModuleIndex2(a) || 0) < (chunkGroup.getModuleIndex2(b) || 0) ? 1 : -1
+        (a, b) =>
+          (chunkGroup.getModuleIndex2(a) || 0) <
+          (chunkGroup.getModuleIndex2(b) || 0)
+            ? 1
+            : -1
       );
     } else {
       // fallback for older webpack versions


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **metadata update**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**

### Motivation / Use-Case
Modules with undefined ID will now be sorted to the bottom of array, and imported after the once with and ID

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
