### PR TITLE
fix: add empty id to prevent contenthash from changing unnecessarily

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ class CssDependencyTemplate {
 class CssModule extends webpack.Module {
   constructor(dependency) {
     super(MODULE_TYPE, dependency.context);
+    this.id = '';
     this._identifier = dependency.identifier;
     this._identifierIndex = dependency.identifierIndex;
     this.content = dependency.content;
@@ -92,7 +93,7 @@ class CssModule extends webpack.Module {
     super.updateHash(hash);
     hash.update(this.content);
     hash.update(this.media || '');
-    hash.update(JSON.stringify(this.sourceMap || ''));
+    hash.update(this.sourceMap ? JSON.stringify(this.sourceMap) : '');
   }
 }
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Content hashes change when the entries order or length change.

See: https://github.com/webpack-contrib/mini-css-extract-plugin/issues/281

### Additional Info

Reproducible repo: https://github.com/lfre/mini-css-extract-plugin-contenthash
