### PR TITLE
fix 'Cannot read property 'pop' of undefined'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -461,6 +461,9 @@ class MiniCssExtractPlugin {
         }
 
         if (!success) {
+          if (!bestMatch) {
+            break;
+          }
           // no module found => there is a conflict
           // use list with fewest failed deps
           // and emit a warning


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This quick patch fix the error I get while building my app:
```
ERROR in chunk vendor [initial]
styles/vendor.2b18cc82139defdd381f.css
Cannot read property 'pop' of undefined
TypeError: Cannot read property 'pop' of undefined
    at MiniCssExtractPlugin.renderContentAsset (/Users/tdebarochez/repo/node_modules/mini-css-extract-plugin/dist/index.js:342:44)
    at Object.render (/Users/tdebarochez/repo/node_modules/mini-css-extract-plugin/dist/index.js:174:32)
    at Compilation.createChunkAssets (/Users/tdebarochez/repo/node_modules/webpack/lib/Compilation.js:2427:29)
...
```

### Breaking Changes

N/A

### Additional Info

Disclaimer: I absolutely don't know what I am doing. The only thing I know is that fix my build process. I didn't get this error before upgrading my package-lock.json to node v10.
If someone can tell me how to target the fail module, I could provide a reproductible test case.