### PR TITLE
Remove unnecessary setting of filename and chunkFilename in devMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ module.exports = {
     new MiniCssExtractPlugin({
       // Options similar to the same options in webpackOptions.output
       // both options are optional
-      filename: devMode ? '[name].css' : '[name].[hash].css',
-      chunkFilename: devMode ? '[id].css' : '[id].[hash].css',
+      filename: '[name].[hash].css',
+      chunkFilename: '[id].[hash].css',
     })
   ],
   module: {


### PR DESCRIPTION
Since the example don't use the plugin in devMode at all, there is no reason to have a special filename configuration for the devMode.

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The example may confuse users, or they use things in their config which are not required, just like me, before I've realized that it doesn't make sense.
