### PR TITLE
Avoid `this[MODULE_TYPE] is not a function` error

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -124,7 +124,7 @@ export function pitch(request) {
           };
         });
       }
-      if(typeof this[MODULE_TYPE] !== "function") {
+      if(typeof this[MODULE_TYPE] !== 'function') {
         return callback(new Error("It seems you are using the loader but forgot to register the plugin"));
       }
       this[MODULE_TYPE](text);

--- a/src/loader.js
+++ b/src/loader.js
@@ -125,7 +125,7 @@ export function pitch(request) {
         });
       }
       if(typeof this[MODULE_TYPE] !== 'function') {
-        return callback(new Error("It seems you are using the loader but forgot to register the plugin"));
+        return callback(new Error('It seems you are using the loader but forgot to register the plugin'));
       }
       this[MODULE_TYPE](text);
     } catch (e) {

--- a/src/loader.js
+++ b/src/loader.js
@@ -124,6 +124,9 @@ export function pitch(request) {
           };
         });
       }
+      if(typeof this[MODULE_TYPE] !== "function") {
+        return callback(new Error("It seems you are using the loader but forgot to register the plugin"));
+      }
       this[MODULE_TYPE](text);
     } catch (e) {
       return callback(e);


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Following https://github.com/webpack-contrib/mini-css-extract-plugin/issues/73#issuecomment-441717981

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

No
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

I didn't add a test because I made this fix from GitHub UI :)