### PR TITLE
feat: onEmit configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ module.exports = {
       // both options are optional
       filename: devMode ? '[name].css' : '[name].[hash].css',
       chunkFilename: devMode ? '[id].css' : '[id].[hash].css',
+      // optional callback allows post-processing of the modules produced by the plugin. `modules` is a Set in the
+      // final output order; you can mutate the set, or return a new set. `chunk.name` provides the name of the chunk
+      onEmit: function(chunk, modules) {
+        if (chunk.name === 'some-chunk') {
+          return processModules(modules);
+        }
+      },
+    }),
     })
   ],
   module: {

--- a/src/index.js
+++ b/src/index.js
@@ -500,6 +500,14 @@ class MiniCssExtractPlugin {
       modules.sort((a, b) => a.index2 - b.index2);
       usedModules = modules;
     }
+
+    if (this.options.onEmit) {
+      const replaced = this.options.onEmit(chunk, usedModules);
+      if (replaced) {
+        usedModules = replaced;
+      }
+    }
+
     const source = new ConcatSource();
     const externalsSource = new ConcatSource();
     for (const m of usedModules) {

--- a/test/cases/on-emit/a.css
+++ b/test/cases/on-emit/a.css
@@ -1,0 +1,1 @@
+body { background: red; }

--- a/test/cases/on-emit/b.css
+++ b/test/cases/on-emit/b.css
@@ -1,0 +1,1 @@
+body { background: green; }

--- a/test/cases/on-emit/expected/main.css
+++ b/test/cases/on-emit/expected/main.css
@@ -1,0 +1,4 @@
+body { background: green; }
+
+body { background: red; }
+

--- a/test/cases/on-emit/index.js
+++ b/test/cases/on-emit/index.js
@@ -1,0 +1,2 @@
+import './a.css';
+import './b.css';

--- a/test/cases/on-emit/webpack.config.js
+++ b/test/cases/on-emit/webpack.config.js
@@ -1,0 +1,24 @@
+const Self = require('../../../');
+
+module.exports = {
+  entry: './index.js',
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [Self.loader, 'css-loader'],
+      },
+    ],
+  },
+  plugins: [
+    new Self({
+      filename: '[name].css',
+      onEmit: function(chunk, modules) {
+        if (chunk.name !== 'main') {
+          throw new Error('Chunk object was not passed correctly');
+        }
+        return new Set(Array.from(modules).reverse());
+      },
+    }),
+  ],
+};


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

We need to lock the order that CSS appears in assets produced by mini-css-extract-plugin over time. We've implemented this my maintaining a lock file that persists the order of CSS modules when they are first seen, but this requires post-processing of the final list produced by the plugin to enforce the order when the bundles are built.

This pull request adds a hook so consumers can optionally post-process the final set of "used modules" before they are returned to webpack.

### Breaking Changes

None

### Additional Info

None