### PR TITLE
Some small optimizations for stylesheet injection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -353,7 +353,6 @@ class MiniCssExtractPlugin {
                   '}',
                   'var linkTag = document.createElement("link");',
                   'linkTag.rel = "stylesheet";',
-                  'linkTag.type = "text/css";',
                   'linkTag.onload = resolve;',
                   'linkTag.onerror = function(event) {',
                   Template.indent([
@@ -368,7 +367,7 @@ class MiniCssExtractPlugin {
                   'linkTag.href = fullhref;',
                   crossOriginLoading
                     ? Template.asString([
-                        `if (linkTag.href.indexOf(window.location.origin + '/') !== 0) {`,
+                        `if (linkTag.href.indexOf(location.origin + '/') !== 0) {`,
                         Template.indent(
                           `linkTag.crossOrigin = ${JSON.stringify(
                             crossOriginLoading
@@ -377,8 +376,7 @@ class MiniCssExtractPlugin {
                         '}',
                       ])
                     : '',
-                  'var head = document.getElementsByTagName("head")[0];',
-                  'head.appendChild(linkTag);',
+                  'document.head.appendChild(linkTag);',
                 ]),
                 '}).then(function() {',
                 Template.indent(['installedCssChunks[chunkId] = 0;']),


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** _(not yet!)_
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

There are a few cases where the code injected into a bundle could be a bit smaller. I've addressed two really simple ones here - removing the `type` property from `<link rel=stylesheet>`, and using `document.head` ([IE9+](https://developer.mozilla.org/en-US/docs/Web/API/Document/head)) instead of `getElementsByTagName('head')[0]`.


### Breaking Changes

This requires IE9+. Not sure if there's a browser support target for mini-css-extract-plugin that makes this prohibitive.