### PR TITLE
Add insert before option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -378,7 +378,9 @@ class MiniCssExtractPlugin {
                       ])
                     : '',
                   'var head = document.getElementsByTagName("head")[0];',
-                  'head.appendChild(linkTag);',
+                  'var insertBefore = document.getElementById("mini-css-before")',
+                  'if(insertBefore) head.insertBefore(linkTag, insertBefore);',
+                  'else head.appendChild(linkTag);',
                 ]),
                 '}).then(function() {',
                 Template.indent(['installedCssChunks[chunkId] = 0;']),


### PR DESCRIPTION
We have an ordering problem with `mini-css-extract-plugin` for production build.

- Dev build use `style-loader` and the package has an option to insert style like:

```
insertAt: {
  before: '#mini-css-before'
},
```

- Prod build use `mini-css-extract-plugin` and the package has no option for insert before.

So I make a change in this PR. The logic here is finding the tag that has Id called `mini-css-before` and set insert before the tag.