### PR TITLE
feat: export class names as an ESM

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -130,7 +130,13 @@ export function pitch(request) {
     }
     let resultSource = `// extracted by ${pluginName}`;
     if (locals && typeof resultSource !== 'undefined') {
-      resultSource += `\nmodule.exports = ${JSON.stringify(locals)};`;
+      Object.keys(locals).forEach((exportName) => {
+        const className = locals[exportName];
+
+        resultSource += `\nexport const ${exportName} = '${className}';`;
+      });
+
+      resultSource += `\nexport default ${JSON.stringify(locals)};`;
     }
 
     return callback(null, resultSource);


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Closes #43.

Consuming class names as an ESM with named exports makes Webpack to include them as separate bindings, which in turn, allows minifires to mangle them or inline those class names.

It all leads to a reduced size of a bundle, which, in case of our app, was `~30Kib` of a minified code.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

This a backward-compatible change due to an interoperability between ESM and CJS implemented in Webpack.

### Additional Info

Tests weren't updated because none of them assert exports of JS modules. Unfortunately, I've no idea how it can be tested given the existing cases.