### PR TITLE
Added option to disable async loading of CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,16 @@ new MiniCssExtractPlugin({
 }),
 ```
 
+### Disable Asynchronous Downloading of CSS
+
+For projects in which you do not want CSS asynchronously fetched on the client side, and only want the CSS that is delivered on the server side (via link tags) to be fetched and parsed, enabling this option will give you that functionality.
+
+```javascript
+new MiniCssExtractPlugin({
+  disableAsync: true,
+}),
+```
+
 ### Media Query Plugin
 
 If you'd like to extract the media queries from the extracted CSS (so mobile users don't need to load desktop or tablet specific CSS anymore) you should use one of the following plugins:

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:watch": "cross-env NODE_ENV=test jest --watch",
     "test:coverage": "cross-env NODE_ENV=test jest --collectCoverageFrom=\"src/**/*.js\" --coverage",
     "test:manual": "webpack-dev-server test/manual/src/index.js --open --config test/manual/webpack.config.js",
+    "test:manualDisableAsync": "webpack-dev-server test/manualDisableAsyncOption/src/index.js --open --config test/manualDisableAsyncOption/webpack.config.js",
     "pretest": "npm run lint",
     "test": "cross-env NODE_ENV=test npm run test:coverage",
     "defaults": "webpack-defaults"

--- a/src/index.js
+++ b/src/index.js
@@ -304,6 +304,8 @@ class MiniCssExtractPlugin {
       mainTemplate.hooks.requireEnsure.tap(
         pluginName,
         (source, chunk, hash) => {
+          if (this.options.disableAsync) return null;
+          
           const chunkMap = this.getCssChunkObject(chunk);
 
           if (Object.keys(chunkMap).length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -305,7 +305,6 @@ class MiniCssExtractPlugin {
         pluginName,
         (source, chunk, hash) => {
           if (this.options.disableAsync) return null;
-          
           const chunkMap = this.getCssChunkObject(chunk);
 
           if (Object.keys(chunkMap).length > 0) {

--- a/test/manualDisableAsyncOption/index.html
+++ b/test/manualDisableAsyncOption/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>mini-css-extract-plugin testcase</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" type="text/css" href="/dist/a.css" />
+</head>
+<body>
+  <script type="text/javascript" src="/dist/a.js"></script>
+  <script type="text/javascript" src="/dist/b.js"></script>
+  <script type="text/javascript" src="/dist/main.js"></script>
+</body>
+</html>

--- a/test/manualDisableAsyncOption/src/a.css
+++ b/test/manualDisableAsyncOption/src/a.css
@@ -1,0 +1,7 @@
+.container {
+  background: blue;
+  color: red;
+  width: 100%;
+  height: 20px;
+  text-align: center;
+}

--- a/test/manualDisableAsyncOption/src/b.css
+++ b/test/manualDisableAsyncOption/src/b.css
@@ -1,0 +1,7 @@
+.container {
+  background: purple;
+  color: green;
+  width: 100%;
+  height: 20px;
+  text-align: center;
+}

--- a/test/manualDisableAsyncOption/src/index.js
+++ b/test/manualDisableAsyncOption/src/index.js
@@ -1,0 +1,14 @@
+/* eslint-env browser */
+
+import './a.css';
+import './b.css';
+
+const render = () => {
+  const div = document.createElement('div');
+  div.setAttribute('class', 'container');
+  const text = 'My background color should be blue, and my text should be red!';
+  div.innerHTML = text;
+  document.body.appendChild(div);
+};
+
+render();

--- a/test/manualDisableAsyncOption/webpack.config.js
+++ b/test/manualDisableAsyncOption/webpack.config.js
@@ -1,0 +1,45 @@
+const Self = require('../../');
+
+module.exports = {
+  mode: 'development',
+  output: {
+    chunkFilename: '[name].js',
+    publicPath: '/dist/',
+    crossOriginLoading: 'anonymous',
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        default: false,
+        a: {
+          name: 'a',
+          test: /a.css/,
+          chunks: 'all',
+          enforce: true,
+        },
+        b: {
+          name: 'b',
+          test: /b.css/,
+          chunks: 'all',
+          enforce: true,
+        },
+      },
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [Self.loader, 'css-loader'],
+      },
+    ],
+  },
+  plugins: [
+    new Self({
+      filename: '[name].css',
+    }),
+  ],
+  devServer: {
+    contentBase: __dirname,
+  },
+};


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [X] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The reason for this PR are for the scenarios in which you have multiple branded websites, all using the same components, but different styles based off the brand. Lets say we have a component that looks like this:

```
import React from 'react';
import PropTypes from 'prop-types';
import { A, B, C } from 'config/brands';

const brandStyles = {};
brandStyles[A] = require('./styles.a.scss'); // version A of the component styling
brandStyles[B] = require('./styles.b.scss'); // version B of the component styling
brandStyles[C] = require('./styles.c.scss'); // version C of the component styling

const BrandedComponent = ({ brand, ... }) => {
  const styles = brandStyles[brand] || brandStyles[A];

  return (
    <div className={styles.container}>
      ...
    </div>
  )
}

export default BrandedComponent;
```

Notice how there's an A, B, and C stylesheet. This is because using a different stylesheet, we can drastically change how the component looks in our application, essentially creating different branded versions of it. Depending on the brand you hit, the correct stylesheet will be applied.

The way I've compiled the stylesheets is so that there's a `global.css`, `a.css` (all the styles.a.scss files), `b.css` (all the styles.b.scss files), `c.css` (all the styles.c.scss files) ...etc files. Depending on the brand you hit, I attach the correct stylesheets in a link tag to the page source so the browser will download them.

If I had not disabled the async loading of styles, the other brand styles being required at the top of the component would have been asynchronously downloaded, sometimes causing the component to not look as I wanted it to.

This has been asked for before in issues, so I figured we can't be the only ones who needed a feature like this:

https://github.com/webpack-contrib/mini-css-extract-plugin/issues/204

With this PR, you can now disable mini css extract from asynchronously downloading other stylesheets, by providing it the `disableAsync` option.

```
new MiniCssExtractPlugin({ filename: "[name].css", disableAsync: true })
```

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

None

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
