### PR TITLE
feat: add option to disable plugin warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,19 @@ module.exports = {
 
 For long term caching use `filename: "[contenthash].css"`. Optionally add `[name]`.
 
+#### Disabling conflicting order warnings
+
+Option `disableWarnings: boolean`. Default: `false`
+
+To disable plugin warnings pass `disableWarnings: true` to the plugin options:
+```
+plugins: [
+  new MiniCssExtractPlugin({
+    disableWarnings: true
+  })
+],
+```
+
 ### Media Query Plugin
 
 If you'd like to extract the media queries from the extracted CSS (so mobile users don't need to load desktop or tablet specific CSS anymore) you should use one of the following plugins:

--- a/src/index.js
+++ b/src/index.js
@@ -480,16 +480,20 @@ class MiniCssExtractPlugin {
           // use list with fewest failed deps
           // and emit a warning
           const fallbackModule = bestMatch.pop();
-          compilation.warnings.push(
-            new Error(
-              `chunk ${chunk.name || chunk.id} [mini-css-extract-plugin]\n` +
-                'Conflicting order between:\n' +
-                ` * ${fallbackModule.readableIdentifier(requestShortener)}\n` +
-                `${bestMatchDeps
-                  .map((m) => ` * ${m.readableIdentifier(requestShortener)}`)
-                  .join('\n')}`
-            )
-          );
+          if (!this.options.disableWarnings) {
+            compilation.warnings.push(
+              new Error(
+                `chunk ${chunk.name || chunk.id} [mini-css-extract-plugin]\n` +
+                  'Conflicting order between:\n' +
+                  ` * ${fallbackModule.readableIdentifier(
+                    requestShortener
+                  )}\n` +
+                  `${bestMatchDeps
+                    .map((m) => ` * ${m.readableIdentifier(requestShortener)}`)
+                    .join('\n')}`
+              )
+            );
+          }
           usedModules.add(fallbackModule);
         }
       }


### PR DESCRIPTION
An option that prevents emitting conflicting order warnings

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

On a large project with a lot of internal dependencies, there may be a lot of conflicting order warnings. 
Sometimes it is OK, because conflicting files may not contain intersecting selectors. 
Disabling warnings in webpack stats config will not turn off these, so it would be great to have an option to disable plugin's warnings.
