### PR TITLE
feat: add orderWarnings flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ module.exports = {
       // Options similar to the same options in webpackOptions.output
       // both options are optional
       filename: "[name].css",
-      chunkFilename: "[id].css"
+      chunkFilename: "[id].css",
+      orderWarning: true // Disable to remove warnings about conflicting order
     })
   ],
   module: {

--- a/src/index.js
+++ b/src/index.js
@@ -113,6 +113,7 @@ class MiniCssExtractPlugin {
     this.options = Object.assign(
       {
         filename: '[name].css',
+        orderWarning: true,
       },
       options
     );
@@ -480,16 +481,20 @@ class MiniCssExtractPlugin {
           // use list with fewest failed deps
           // and emit a warning
           const fallbackModule = bestMatch.pop();
-          compilation.warnings.push(
-            new Error(
-              `chunk ${chunk.name || chunk.id} [mini-css-extract-plugin]\n` +
-                'Conflicting order between:\n' +
-                ` * ${fallbackModule.readableIdentifier(requestShortener)}\n` +
-                `${bestMatchDeps
-                  .map((m) => ` * ${m.readableIdentifier(requestShortener)}`)
-                  .join('\n')}`
-            )
-          );
+          if (this.options.orderWarning) {
+            compilation.warnings.push(
+              new Error(
+                `chunk ${chunk.name || chunk.id} [mini-css-extract-plugin]\n` +
+                  'Conflicting order between:\n' +
+                  ` * ${fallbackModule.readableIdentifier(
+                    requestShortener
+                  )}\n` +
+                  `${bestMatchDeps
+                    .map((m) => ` * ${m.readableIdentifier(requestShortener)}`)
+                    .join('\n')}`
+              )
+            );
+          }
           usedModules.add(fallbackModule);
         }
       }


### PR DESCRIPTION
The flag defaults to true, which retains the existing behaviour of
warnings when there is conflicting import order between multiple CSS
files. When set to false, these warnings are not generated.

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

As has been pointed out in https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250:
- Sorting all imports (not just in files but in tree traversal import order is difficult to do in a large project, and impossible if there are async chunks with CSS.
- Consistent use of scoping or naming conventions in CSS makes the order of CSS import irrelevant, and this is a much more manageable strategy for a large project as @jsg2021 said in https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250#issuecomment-416710488
- Using `stats.warningFilter` as recommended by @sokra in https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250#issuecomment-415345126 or [webpack-filter-warnings-plugin](https://github.com/mattlewis92/webpack-filter-warnings-plugin) does not work consistently. It's much better to avoid generating the warnings at their source (optionally) rather than to partially filter them later with regexes. For example, I use [webpack-error-on-warnings-plugin](https://github.com/hedgepigdaniel/webpack-error-on-warnings-plugin) to enforce that there are no warnings in a build. This is incompatible with filtering warnings, because it the error must happen in the `before-emit` hook so that it prevents emission of assets when there are warnings. The warnings filtering happens in the `done` hook or in the `toJson` method, which is too late.
