### PR TITLE
Add publicPathRelativeToSource option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,46 @@ module.exports = {
 }
 ```
 
+#### URLs relative to the CSS file
+
+URLs in CSS files are resolved by the browser relative to the CSS file itself. The `publicPath` option (above) is used
+to specify where the root of the context is, relative to the CSS file for URLs in the CSS to work. However, having just
+one `publicPath` means that all of your CSS files need to be at the same depth (number of directories deep).
+
+Use the `publicPathRelativeToSource` option to dynamically change the `publicPath` used by the `mini-css-extract-plugin` to
+be relative to your source CSS file. NB: in order for the output to be correct, your output CSS file must be at the same 
+relative depth as your source CSS file.
+
+```js
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+module.exports = {
+  plugins: [
+    new MiniCssExtractPlugin({
+      // Options similar to the same options in webpackOptions.output
+      // both options are optional
+      filename: "[name].css",
+      chunkFilename: "[id].css"
+    })
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              publicPathRelativeToSource: true,
+            }
+          },
+          "css-loader"
+        ]
+      }
+    ]
+  }
+}
+```
+
 #### Advanced configuration example
 
 This plugin should be used only on `production` builds without `style-loader` in the loaders chain, especially if you want to have HMR in `development`.

--- a/src/loader.js
+++ b/src/loader.js
@@ -6,6 +6,7 @@ import NodeTargetPlugin from 'webpack/lib/node/NodeTargetPlugin';
 import LibraryTemplatePlugin from 'webpack/lib/LibraryTemplatePlugin';
 import SingleEntryPlugin from 'webpack/lib/SingleEntryPlugin';
 import LimitChunkCountPlugin from 'webpack/lib/optimize/LimitChunkCountPlugin';
+import path from 'path';
 
 const MODULE_TYPE = 'css/mini-extract';
 const pluginName = 'mini-css-extract-plugin';
@@ -40,6 +41,10 @@ export function pitch(request) {
     filename: childFilename,
     publicPath,
   };
+  if (query.publicPathRelativeToSource) {
+    const relative = path.relative(path.dirname(this.resourcePath), this.rootContext)
+    outputOptions.publicPath = relative + '/'
+  }
   const childCompiler = this._compilation.createChildCompiler(
     `${pluginName} ${request}`,
     outputOptions


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [X] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Addresses #367 by adding a `publicPathRelativeToSource` option to dynamically adjust the `publicPath` passed down to import loaders so that paths in the output CSS will be relative to the source CSS file rather than the context.

The browser treats URLs in CSS files relative to the CSS file, so having URLs be relative to the CSS file is natural in CSS. A common solution is to set `publicPath` to an absolute path, but that isn't always possible. Another common solution is to set `publicPath` to `../`, which assumes that your CSS file is output into `./css/` (or some other folder, but just one folder) and fails if you output a CSS file more than one folder deep.

(URLs in the CSS that comes _into_ `mini-css-extract-plugin` are made relative to the context by `css-loader`, which produces JavaScript where URLs should be relative to the context)

Note that this solution only works if the output CSS is at the same depth relative to the context as the source file.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

N/A

### Additional Info
