### PR TITLE
feat(ordering): add support for insertInto option

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,23 @@ const miniCssExtractPlugin = new MiniCssExtractPlugin({
 
 For long term caching use `filename: "[contenthash].css"`. Optionally add `[name]`.
 
+#### Determining Insertion Point for Async CSS Chunks
+
+If you are extracting CSS into separate files and using Webpack Dynamic Imports, it is possible you will need to be able to configure the insertion point of your async CSS chunks in the document to preserve ordering for the CSS cascade.  This is possible using the `insertInto` option, which takes a function that will be called to determine the parent node into which to insert the `<link>`` tag for the chunk CSs file
+
+```javascript
+module.exports = {
+  ...
+  plugins: [
+    new MiniCssExtractPlugin({
+      filename: "[name].css",
+      insertInto: href => document.querySeletor('.async-styles-container'),
+    })
+  ],
+  ...
+}
+```
+
 ### Remove Order Warnings
 
 If the terminal is getting bloated with chunk order warnings. You can filter by configuring [warningsFilter](https://webpack.js.org/configuration/stats/) withing the webpack stats option

--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,9 @@ class MiniCssExtractPlugin {
       },
       options
     );
-
+    if (typeof this.options.insertInto !== 'function') {
+      throw new Error('insertInto option must be a function');
+    }
     if (!this.options.chunkFilename) {
       const { filename } = this.options;
 
@@ -363,7 +365,9 @@ class MiniCssExtractPlugin {
                 contentHashType: MODULE_TYPE,
               }
             );
-
+            const insertInto = this.options.insertInto
+              ? this.options.insertInto.toString()
+              : 'null';
             return Template.asString([
               source,
               '',
@@ -419,8 +423,8 @@ class MiniCssExtractPlugin {
                         '}',
                       ])
                     : '',
-                  `var selector = "${this.options.insertInto}";`,
-                  'var parent = selector && document.querySelector && document.querySelector(selector);',
+                  `var insertInto = ${insertInto};`,
+                  'var parent = insertInto ? insertInto(href) : null;',
                   'if (parent) { parent.appendChild(linkTag); }',
                   'else { document.getElementsByTagName("head")[0].appendChild(linkTag); }',
                 ]),

--- a/src/index.js
+++ b/src/index.js
@@ -125,6 +125,7 @@ class MiniCssExtractPlugin {
       {
         filename: DEFAULT_FILENAME,
         moduleFilename: () => options.filename || DEFAULT_FILENAME,
+        insertInto: null,
       },
       options
     );
@@ -418,8 +419,10 @@ class MiniCssExtractPlugin {
                         '}',
                       ])
                     : '',
-                  'var head = document.getElementsByTagName("head")[0];',
-                  'head.appendChild(linkTag);',
+                  `var selector = "${this.options.insertInto}";`,
+                  'var parent = selector && document.querySelector && document.querySelector(selector);',
+                  'if (parent) { parent.appendChild(linkTag); }',
+                  'else { document.getElementsByTagName("head")[0].appendChild(linkTag); }',
                 ]),
                 '}).then(function() {',
                 Template.indent(['installedCssChunks[chunkId] = 0;']),


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

The issue being addressed is describe in #370.  This adds a new `insertInto` option that is optional and backwards compatible.  Specifying a CSS selector allows the user to specify a DOM node into which the async-loaded `<link>` tags should be inserted.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

n/a, changes are backwards compatible and will continue to insert `<link>` tags into the `<head>` if no `insertInto` option is specified

### Additional Info

This is a different approach that solves (I think) the same problem as #331, in a more customizable and backwards-compatible way.

This is also seemingly related to #328.
