### PR TITLE
fix: hmr do not crash on link without href

### DIFF
--- a/src/hmr/hotModuleReplacement.js
+++ b/src/hmr/hotModuleReplacement.js
@@ -79,6 +79,10 @@ function getCurrentScriptUrl(moduleId) {
 
 function updateCss(el, url) {
   if (!url) {
+    if (!el.href) {
+      return;
+    }
+
     // eslint-disable-next-line
     url = el.href.split('?')[0];
   }
@@ -140,6 +144,10 @@ function reloadStyle(src) {
   let loaded = false;
 
   forEach.call(elements, (el) => {
+    if (!el.href) {
+      return;
+    }
+
     const url = getReloadUrl(el.href, src);
 
     if (!isUrlRequest(url)) {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

href can be avoided (non standard sutiation)

### Breaking Changes

No

### Additional Info

No