### PR TITLE
fix(options): use filename mutated after instantiation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,7 @@ class MiniCssExtractPlugin {
     this.options = Object.assign(
       {
         filename: DEFAULT_FILENAME,
-        moduleFilename: () => options.filename || DEFAULT_FILENAME,
+        moduleFilename: () => this.options.filename || DEFAULT_FILENAME,
         ignoreOrder: false,
       },
       options

--- a/test/cases/moduleFilenameMutableFilename/expected/mutated.css
+++ b/test/cases/moduleFilenameMutableFilename/expected/mutated.css
@@ -1,0 +1,4 @@
+body {
+  background: palegreen;
+}
+

--- a/test/cases/moduleFilenameMutableFilename/index.js
+++ b/test/cases/moduleFilenameMutableFilename/index.js
@@ -1,0 +1,1 @@
+import './style.css';

--- a/test/cases/moduleFilenameMutableFilename/style.css
+++ b/test/cases/moduleFilenameMutableFilename/style.css
@@ -1,0 +1,3 @@
+body {
+  background: palegreen;
+}

--- a/test/cases/moduleFilenameMutableFilename/webpack.config.js
+++ b/test/cases/moduleFilenameMutableFilename/webpack.config.js
@@ -1,0 +1,27 @@
+const Self = require('../../../');
+
+module.exports = {
+  entry: {
+    main: './index.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [Self.loader, 'css-loader'],
+      },
+    ],
+  },
+  output: {
+    filename: '[name].js',
+  },
+  plugins: [
+    (() => {
+      const self = new Self({ filename: 'constructed.css' });
+
+      self.options.filename = 'mutated.css';
+
+      return self;
+    })(),
+  ],
+};


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [X] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

A minor update from 0.6.0 to 0.7.0 broke my webpacker configuration. :(

In https://github.com/webpack-contrib/mini-css-extract-plugin/commit/13e9cbf3fb58f69e931c564ca4360cef439512c4 (https://github.com/webpack-contrib/mini-css-extract-plugin/pull/381) the `moduleFilename` function was added. This change broke webpacker configurations that set a non-default `filename` option.

To explain further, if you view the [webpacker plugins docs](https://github.com/rails/webpacker/blob/master/docs/webpack.md#plugins), options can be mutated after construction.

Excerpt from docs:

```
// Get a pre-configured plugin
const manifestPlugin = environment.plugins.get('Manifest')
manifestPlugin.options.writeToFileEmit = false
```
So, previously, I could set a filename like so:

```
environment.plugins.get('MiniCssExtractPlugin').options.filename = 'static-[contenthash].css'
```

but after https://github.com/webpack-contrib/mini-css-extract-plugin/commit/13e9cbf3fb58f69e931c564ca4360cef439512c4 this was broken and instead you must set `moduleFilename: () => yourFilename` to fix it.

### Breaking Changes

None

### Additional Info
