### PR TITLE
feat: hmr error recovery

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -31,9 +31,16 @@ function hotLoader(content, context) {
     locals: !!context.locals,
   })});
       module.hot.dispose(cssReload);
+      module.hot.accept(function(){});
       ${accept}
     }
   `;
+}
+
+function interceptError(callback, interceptor) {
+  return (err, source) => {
+    return callback(null, err ? interceptor(err) : source);
+  };
 }
 
 const exec = (loaderContext, code, filename) => {
@@ -133,15 +140,22 @@ export function pitch(request) {
     });
   });
 
-  const callback = this.async();
+  const callback = !options.hmr
+    ? this.async()
+    : interceptError(this.async(), (err) => {
+        let resultSource = `// extracted by ${pluginName}`;
+        resultSource += hotLoader('', {
+          context: this.context,
+          locals: null,
+          options,
+        });
+        resultSource += `\nthrow new Error(${JSON.stringify(String(err))});`;
+        return resultSource;
+      });
 
   childCompiler.runAsChild((err, entries, compilation) => {
     if (err) {
       return callback(err);
-    }
-
-    if (compilation.errors.length > 0) {
-      return callback(compilation.errors[0]);
     }
 
     compilation.fileDependencies.forEach((dep) => {
@@ -151,6 +165,10 @@ export function pitch(request) {
     compilation.contextDependencies.forEach((dep) => {
       this.addContextDependency(dep);
     }, this);
+
+    if (compilation.errors.length > 0) {
+      return callback(compilation.errors[0]);
+    }
 
     if (!source) {
       return callback(new Error("Didn't get a result from child compiler"));


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [X] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This PR implements error-resilience/-recovery for HMR when dealing with failed CSS child compilations. (E.g. syntax errors in Less or Sass code.)

It enables failed compilations to continue to `hot.accept` future compilations, instead of requiring a full reload. This is a significant improvement to workflow, esp. for larger applications that can't deal well with reload and require manually recreating a certain application state.

### Breaking Changes

None, as far as I am aware. All existing test scenarios in the suite continue to pass.

### Additional Info

The [NetMatch/mini-css-extract-plugin-hmr-testcase](https://github.com/NetMatch/mini-css-extract-plugin-hmr-testcase) repository contains a testcase that illustrates the problem; includes a method to switch to the patched fork and illustrate the improvements; and has a rundown of the how/what/why of changes.

A test update will probably still be required to verify the resilience. But I'm having some problems wrapping my head around how the test suite is set up.
Some assistance there would be appreciated.