### PR TITLE
fix(order): find modules from each chunk in group

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -421,7 +421,7 @@ class MiniCssExtractPlugin {
       // This loop also gathers dependencies from the ordered lists
       // Lists are in reverse order to allow to use Array.pop()
       const modulesByChunkGroup = Array.from(chunk.groupsIterable, (cg) => {
-        const sortedModules = modules
+        let sortedModules = modules
           .map((m) => {
             return {
               module: m,
@@ -432,6 +432,18 @@ class MiniCssExtractPlugin {
           .filter((item) => item.index !== undefined)
           .sort((a, b) => b.index - a.index)
           .map((item) => item.module);
+
+        // if no modules were found by getModuleIndex2, dive into each chunk
+        // in the group
+        if (!sortedModules || !sortedModules.length) {
+          sortedModules = cg.chunks
+            // reduce each chunk's modules into a flat array
+            .reduce((arr, ch) => [...arr, ...ch.modulesIterable], [])
+            // filter only the modules that match
+            .filter((m) => modules.find((mod) => mod === m))
+            // sort in reverse order
+            .sort((a, b) => a.index2 - b.index2);
+        }
 
         for (let i = 0; i < sortedModules.length; i++) {
           const set = moduleDependencies.get(sortedModules[i]);


### PR DESCRIPTION
fixes #257

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
As discussed in #257, when the plugin calls `modulesByChunkGroup`, it calls the chunk group's `getModuleIndex2()` function from the ChunkGroup object's `_moduleIndices2` Map property. However, the error occurs because the module it's trying to find the index for doesn't exist in `_moduleIndices2`, causing `modulesByChunkGroup` to return an empty array. The for loop that uses the array never iterates, so `bestMatch` is never set and is left undefined, resulting in an error when trying to call `.pop()` on that undefined object.

This fix checks if `getModuleIndex2()` returns no matching modules and, if so, dives into each chunk in the chunk group to find matching modules.

### Breaking Changes
None.
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
While this solution dives into a chunk group's chunks to find modules that weren't in the chunk group's `_moduleIndices2` property, it might indicate a bug in webpack where that property is not being fully populated as it should be. If that is the case, then this fix should no longer be necessary, but perhaps it wouldn't hurt to have an extra guard for finding chunk modules.