### PR TITLE
Add support for the insert option

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,29 +343,76 @@ module.exports = {
 };
 ```
 
-#### Module Filename Option
+### Plugin Options
+
+#### moduleFilename
 
 With the `moduleFilename` option you can use chunk data to customize the filename. This is particularly useful when dealing with multiple entry points and wanting to get more control out of the filename for a given entry point/chunk. In the example below, we'll use `moduleFilename` to output the generated css into a different directory.
 
 ```javascript
-const miniCssExtractPlugin = new MiniCssExtractPlugin({
+new MiniCssExtractPlugin({
   moduleFilename: ({ name }) => `${name.replace('/js/', '/css/')}.css`,
 });
 ```
 
-#### Long Term Caching
+#### filename
 
 For long term caching use `filename: "[contenthash].css"`. Optionally add `[name]`.
 
-### Remove Order Warnings
+#### ignoreOrder
+
+Removes order warnings.
 
 For projects where css ordering has been mitigated through consistent use of scoping or naming conventions, the css order warnings can be disabled by setting the ignoreOrder flag to true for the plugin.
 
 ```javascript
 new MiniCssExtractPlugin({
   ignoreOrder: true,
-}),
+});
 ```
+
+### insert
+
+Type: `String|Function`
+Default: `head`
+
+By default, the `mini-css-extract-plugin` appends styles (`<link>` elements) to `document.head` of the current `window`.
+
+However in some circumstances it might be necessary to have finer control over the append target or even delay `link` elements instertion. For example this is the case when you asynchronously load styles for an application that runs inside of an iframe. In such cases `insert` can be configured to be a function or a custom selector.
+
+If you target an [iframe](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement) make sure that the parent document can has sufficient access rights to reach into the frame document and append elements to it.
+
+#### `String`
+
+Allows to configure a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector) that will be used to find the element where to append the styles (`link` elements).
+
+```js
+new MiniCssExtractPlugin({
+  insert: '#my-container',
+});
+```
+
+A new `<link>` element will be appended to the `#my-container` element.
+
+#### `Function`
+
+Allows to override default behavior and insert styles at any position.
+
+> ⚠ Do not forget that this code will run in the browser alongside your application. Since not all browsers support latest ECMA features like `let`, `const`, `arrow function expression` and etc we recommend you to use only ECMA 5 features and syntax.
+> ⚠ The `insert` function is serialized to string and passed to the plugin. This means that it won't have access to the scope of the webpack configuration module.
+
+```js
+new MiniCssExtractPlugin({
+  insert: function insert(linkTag) {
+    const reference = document.querySelector('#some-element');
+    if (reference) {
+      reference.parentNode.insertBefore(linkTag, reference);
+    }
+  },
+});
+```
+
+A new `<link>` element will be inserted before the element with id `some-element`.
 
 ### Media Query Plugin
 

--- a/README.md
+++ b/README.md
@@ -380,9 +380,9 @@ By default, the `mini-css-extract-plugin` appends styles (`<link>` elements) to 
 
 However in some circumstances it might be necessary to have finer control over the append target or even delay `link` elements instertion. For example this is the case when you asynchronously load styles for an application that runs inside of an iframe. In such cases `insert` can be configured to be a function or a custom selector.
 
-If you target an [iframe](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement) make sure that the parent document can has sufficient access rights to reach into the frame document and append elements to it.
+If you target an [iframe](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement) make sure that the parent document has sufficient access rights to reach into the frame document and append elements to it.
 
-#### `String`
+#### `insert` as a string
 
 Allows to configure a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector) that will be used to find the element where to append the styles (`link` elements).
 
@@ -394,11 +394,12 @@ new MiniCssExtractPlugin({
 
 A new `<link>` element will be appended to the `#my-container` element.
 
-#### `Function`
+#### `insert` as a function
 
 Allows to override default behavior and insert styles at any position.
 
 > ⚠ Do not forget that this code will run in the browser alongside your application. Since not all browsers support latest ECMA features like `let`, `const`, `arrow function expression` and etc we recommend you to use only ECMA 5 features and syntax.
+
 > ⚠ The `insert` function is serialized to string and passed to the plugin. This means that it won't have access to the scope of the webpack configuration module.
 
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -97,13 +97,23 @@ class CssModuleFactory {
 
 class MiniCssExtractPlugin {
   constructor(options = {}) {
+    const insert =
+      typeof options.insert === 'undefined'
+        ? '"head"'
+        : typeof options.insert === 'string'
+        ? JSON.stringify(options.insert)
+        : options.insert.toString();
+
     this.options = Object.assign(
       {
         filename: DEFAULT_FILENAME,
         moduleFilename: () => this.options.filename || DEFAULT_FILENAME,
         ignoreOrder: false,
       },
-      options
+      options,
+      {
+        insert,
+      }
     );
 
     if (!this.options.chunkFilename) {
@@ -316,6 +326,8 @@ class MiniCssExtractPlugin {
               }
             );
 
+            const { insert } = this.options;
+
             return Template.asString([
               source,
               '',
@@ -371,8 +383,9 @@ class MiniCssExtractPlugin {
                         '}',
                       ])
                     : '',
-                  'var head = document.getElementsByTagName("head")[0];',
-                  'head.appendChild(linkTag);',
+                  `var insert = ${insert};`,
+                  `if (typeof insert === 'function') { insert(linkTag); }`,
+                  `else { var target = document.querySelector(${insert}); target && target.appendChild(linkTag); } `,
                 ]),
                 '}).then(function() {',
                 Template.indent(['installedCssChunks[chunkId] = 0;']),

--- a/src/loader.js
+++ b/src/loader.js
@@ -75,6 +75,7 @@ export function pitch(request) {
       : typeof options.publicPath === 'function'
       ? options.publicPath(this.resourcePath, this.rootContext)
       : this._compilation.outputOptions.publicPath;
+
   const outputOptions = {
     filename: childFilename,
     publicPath,

--- a/src/options.json
+++ b/src/options.json
@@ -10,6 +10,17 @@
           "instanceof": "Function"
         }
       ]
+    },
+    "insert": {
+      "description": "Inserts `<link>` at the given position (https://github.com/webpack-contrib/mini-css-extract-plugin#insert).",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "instanceof": "Function"
+        }
+      ]
     }
   },
   "errorMessages": {

--- a/test/cases/insert-function/expected/main.css
+++ b/test/cases/insert-function/expected/main.css
@@ -1,0 +1,4 @@
+body {
+  background: red;
+}
+

--- a/test/cases/insert-function/index.js
+++ b/test/cases/insert-function/index.js
@@ -1,0 +1,1 @@
+import './style.css';

--- a/test/cases/insert-function/insert-function.test.js
+++ b/test/cases/insert-function/insert-function.test.js
@@ -1,0 +1,33 @@
+/* globals document, getComputedStyle */
+
+import path from 'path';
+
+import webpack from 'webpack';
+
+import config from './webpack.config';
+
+describe('options.insert as a function', () => {
+  it('inserts the bundle on the page', (done) => {
+    const outputPath = path.resolve(__dirname, 'expected/index.js');
+    webpack({
+      ...config,
+      output: {
+        path: outputPath,
+        libraryTarget: 'umd',
+        library: 'mini',
+      },
+    }).run(() => {
+      let computedValue = getComputedStyle(document.body).backgroundColor;
+      expect(computedValue).toBe('');
+
+      const script = document.createElement('script');
+      script.src = outputPath;
+      document.head.appendChild(script);
+
+      computedValue = getComputedStyle(document.body).backgroundColor;
+      expect(computedValue).toBe('rgba(0, 0, 0, 0)');
+
+      done();
+    });
+  });
+});

--- a/test/cases/insert-function/style.css
+++ b/test/cases/insert-function/style.css
@@ -1,0 +1,3 @@
+body {
+  background: red;
+}

--- a/test/cases/insert-function/webpack.config.js
+++ b/test/cases/insert-function/webpack.config.js
@@ -1,0 +1,22 @@
+/* globals document */
+import Self from '../../../src';
+
+module.exports = {
+  entry: './index.js',
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [Self.loader, 'css-loader'],
+      },
+    ],
+  },
+  plugins: [
+    new Self({
+      filename: '[name].css',
+      insert: function insert(linkTag) {
+        document.head.appendChild(linkTag);
+      },
+    }),
+  ],
+};

--- a/test/cases/insert-string/expected/main.css
+++ b/test/cases/insert-string/expected/main.css
@@ -1,0 +1,4 @@
+body {
+  background: red;
+}
+

--- a/test/cases/insert-string/index.js
+++ b/test/cases/insert-string/index.js
@@ -1,0 +1,1 @@
+import './style.css';

--- a/test/cases/insert-string/style.css
+++ b/test/cases/insert-string/style.css
@@ -1,0 +1,3 @@
+body {
+  background: red;
+}

--- a/test/cases/insert-string/webpack.config.js
+++ b/test/cases/insert-string/webpack.config.js
@@ -1,0 +1,19 @@
+import Self from '../../../src';
+
+module.exports = {
+  entry: './index.js',
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [Self.loader, 'css-loader'],
+      },
+    ],
+  },
+  plugins: [
+    new Self({
+      filename: '[name].css',
+      insert: 'head',
+    }),
+  ],
+};

--- a/test/manual/webpack.config.js
+++ b/test/manual/webpack.config.js
@@ -1,3 +1,4 @@
+/* globals document */
 const Self = require('../../');
 
 module.exports = {
@@ -19,6 +20,9 @@ module.exports = {
     new Self({
       filename: '[name].css',
       chunkFilename: '[contenthash].css',
+      insert: function insert(linkTag) {
+        document.head.appendChild(linkTag);
+      },
     }),
   ],
   devServer: {


### PR DESCRIPTION
This PR contains a:

New *feature*.

### Motivation / Use-Case

This new option mirrors the behavior of `style-loader` which allows users to pass a custom `insert` function that takes care of inserting chunks. This is particularly useful when the initiator is in the parent window but the application renders inside of an `iframe`.

### Breaking Changes

None. This change is backwards compatible: when this option is not provided the plugin will keep inserting link tags as before i.e. to the document's `head`.

### Additional Info

I found a similar PR https://github.com/webpack-contrib/mini-css-extract-plugin/pull/371 but the proposed API forces the user to return an element that the plugin will use as insertion point.