### PR TITLE
Add option to export as ES Module

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -202,7 +202,9 @@ export function pitch(request) {
 
     let resultSource = `// extracted by ${pluginName}`;
     const result = locals
-      ? `\nmodule.exports = ${JSON.stringify(locals)};`
+      ? (options.useExport ?
+         `\nexport default ${JSON.stringify(locals)};` :
+         `\nmodule.exports = ${JSON.stringify(locals)};`)
       : '';
 
     resultSource += options.hmr


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

With this simple option Webpack can entirely remove internal CSS names from all source files. Consider the following simple project:
https://gist.github.com/laverdet/560a89734324c114f4e1646ae6283f2e

If you run without the new option you can find this in `dist/main.js`. Note that "container" is still visible in the generated source file:

`e.exports={container:"RX7MVaJTvfI0d1TLV5iSh"}` ... `function(e,t,n){"use strict";n.r(t);var r=n(0),o=n.n(r);console.log(o.a.container)}`

Running with the new option you'll see Webpack can just inject the classname wherever it's needed. The original "container" classname is no longer visible. With aggressive classname mangling you can drop some bytes.

`function(e,t,r){"use strict";r.r(t);console.log("RX7MVaJTvfI0d1TLV5iSh")}`

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

None

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->