### PR TITLE
test: fix invalid test and source map test

### DIFF
--- a/test/cases/no-source-map/expected/main.css
+++ b/test/cases/no-source-map/expected/main.css
@@ -1,0 +1,4 @@
+body {
+  background: red;
+}
+

--- a/test/cases/no-source-map/index.js
+++ b/test/cases/no-source-map/index.js
@@ -1,0 +1,1 @@
+import './style.css';

--- a/test/cases/no-source-map/style.css
+++ b/test/cases/no-source-map/style.css
@@ -1,0 +1,3 @@
+body {
+  background: red;
+}

--- a/test/cases/no-source-map/webpack.config.js
+++ b/test/cases/no-source-map/webpack.config.js
@@ -2,7 +2,8 @@ import Self from '../../../src';
 
 module.exports = {
   entry: './index.js',
-  devtool: 'source-map',
+  // Required to disable source maps in webpack@4
+  devtool: false,
   module: {
     rules: [
       {
@@ -14,7 +15,7 @@ module.exports = {
           {
             loader: 'css-loader',
             options: {
-              sourceMap: true,
+              sourceMap: false,
             },
           },
         ],


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes #285

### Breaking Changes

No

### Additional Info

To disable source maps generation you need set `sourceMap: false` for `css-loader` and set `devtools: false`, we will try to fix and simplify it in webpack@5