### PR TITLE
feat: Enable `esModule` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,12 +155,12 @@ module.exports = {
 ### `esModule`
 
 Type: `Boolean`
-Default: `false`
+Default: `true`
 
-By default, `mini-css-extract-plugin` generates JS modules that use the CommonJS modules syntax.
+By default, `mini-css-extract-plugin` generates JS modules that use the ES module syntax.
 There are some cases in which using ES modules is beneficial, like in the case of [module concatenation](https://webpack.js.org/plugins/module-concatenation-plugin/) and [tree shaking](https://webpack.js.org/guides/tree-shaking/).
 
-You can enable a ES module syntax using:
+If you instead require the output to use CommonJS module syntax, disable `esModule` mode like so:
 
 **webpack.config.js**
 
@@ -177,7 +177,7 @@ module.exports = {
           {
             loader: MiniCssExtractPlugin.loader,
             options: {
-              esModule: true,
+              esModule: false,
             },
           },
           'css-loader',

--- a/src/loader.js
+++ b/src/loader.js
@@ -204,7 +204,7 @@ export function pitch(request) {
     }
 
     const esModule =
-      typeof options.esModule !== 'undefined' ? options.esModule : false;
+      typeof options.esModule !== 'undefined' ? options.esModule : true;
     const result = locals
       ? `\n${esModule ? 'export default' : 'module.exports ='} ${JSON.stringify(
           locals


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Since it can allow webpack's module concatenation and tree shaking to work more effectively, and having `esModule` disabled by default means more boilerplate and having to know that the feature exists.

### Breaking Changes

None, since webpack 4 supports ES Modules syntax out of the box (and doesn't output ESM itself), and this plugin only supports webpack 4 and newer.

### Additional Info

Fixes #485.