### PR TITLE
feat: link preload support (#142)

### DIFF
--- a/src/plugin-options.json
+++ b/src/plugin-options.json
@@ -13,6 +13,9 @@
     },
     "ignoreOrder": {
       "type": "boolean"
+    },
+    "cssPreload": {
+      "type": "boolean"
     }
   }
 }

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -51,6 +51,11 @@
     <p>An error should have appeared.</p>
     <p>Now if you turn the network back on and click it again, it should turn aqua.</p>
   </div>
+  <div class="test lazy-link-preload">
+    <p>Lazy CSS: Must be red.</p>
+    <p><button class="lazy-link-preload-button">Pressing this button</button> displays an alert with check for link preload</p>
+    <p>After click on alert should turn green.</p>
+  </div>
   <div class="test preloaded-css1">
     <p>Preloaded CSS: Must be green.</p>
     <p><button class="preloaded-button1">Pressing this button</button> displays an alert and should turn red.</p>

--- a/test/manual/src/index.js
+++ b/test/manual/src/index.js
@@ -45,6 +45,23 @@ const makeButton = (className, fn, shouldDisable = true) => {
 makeButton('.lazy-button', () => import('./lazy.js'));
 makeButton('.lazy-button2', () => import('./lazy2.css'));
 
+makeButton('.lazy-link-preload-button', () => {
+  const promise = import('./lazy-link-preload.css');
+  const linkElement = Array.from(document.head.children)
+    .slice(-2)
+    .find((el) => {
+      return el.tagName === 'LINK';
+    });
+
+  alert(
+    `Is css preloaded by <link rel="preload"/>? - ${
+      linkElement.getAttribute('rel') === 'preload' ? 'yes' : 'no'
+    }`
+  );
+
+  return promise;
+});
+
 makeButton('.preloaded-button1', () =>
   import(/* webpackChunkName: "preloaded1" */ './preloaded1')
 );

--- a/test/manual/src/lazy-link-preload.css
+++ b/test/manual/src/lazy-link-preload.css
@@ -1,0 +1,3 @@
+.lazy-link-preload {
+  background: lightgreen;
+}


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
This pull request adds \<link rel="preload"\> support, per this issue: [#142](https://github.com/webpack-contrib/mini-css-extract-plugin/issues/142).

It is also an alternative realization of [#344](https://github.com/webpack-contrib/mini-css-extract-plugin/pull/344) pull request, which is not merged and is not active last 4 months.

It was inspired by article about async css load - https://www.filamentgroup.com/lab/load-css-simpler/

Main features:
1. Browser do not block rendering while downloading css file
2. Improve load performance, improve Chrome Lighthouse score (more details at https://developers.google.com/web/tools/lighthouse/audits/preload)
3. Fallback for browsers which doesn't support \<link rel="preload"\>. It simply uses a media type that doesn't match the current environment (\<link media="print"\>), which doesn't block browser render while file is downloading, and changes media after file load (more details in https://www.filamentgroup.com/lab/load-css-simpler/#breaking-that-down%E2%80%A6)

New feature could be disabled by providing `cssPreload: false` into `mini-css-extract-plugin` config


### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->
No breaking changes.

### Additional Info
