### PR TITLE
Avoid HMR crash when src is undefined

### DIFF
--- a/src/hmr/hotModuleReplacement.js
+++ b/src/hmr/hotModuleReplacement.js
@@ -52,7 +52,7 @@ function getCurrentScriptUrl(moduleId) {
 
   return function(fileMap) {
     if (!src) {
-      return null;
+      return [];
     }
 
     const splitResult = src.split(/([^\\/]+)\.js$/);


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
The function returned by `getCurrentScriptUrl` usually returns an array. However when `!src` is true it returns `null`.

This causes a crash when `getReloadUrl()` is run and tries to execute ` src.some((url) =>)`

https://github.com/webpack-contrib/mini-css-extract-plugin/blob/master/src/hmr/hotModuleReplacement.js#L137

This instead returns an empty array instead so that it can always safely be assumed that an array will be returned.

I couldn't find any reason to return `null` instead, but if there is a reason. Another option would be to have a guard before or inside `reloadStyle`.

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes
None that I am aware of.
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

Log from our setup. This happens every time we change a CSS file, and occasionally when just changing a JS file.

```
hotModuleReplacement.js:130 Uncaught TypeError: Cannot read property 'some' of null
    at getReloadUrl (hotModuleReplacement.js:130)
    at hotModuleReplacement.js:148
    at NodeList.forEach (<anonymous>)
    at reloadStyle (hotModuleReplacement.js:142)
    at update (hotModuleReplacement.js:197)
    at functionCall (hotModuleReplacement.js:24)
getReloadUrl @ hotModuleReplacement.js:130
(anonymous) @ hotModuleReplacement.js:148
reloadStyle @ hotModuleReplacement.js:142
update @ hotModuleReplacement.js:197
functionCall @ hotModuleReplacement.js:24
setTimeout (async)
(anonymous) @ hotModuleReplacement.js:28
hotApply @ bootstrap:607
(anonymous) @ bootstrap:362
Promise.then (async)
hotUpdateDownloaded @ bootstrap:361
hotAddUpdateChunk @ bootstrap:337
webpackHotUpdateCallback @ bootstrap:57
(anonymous) @ application-874885fd2d95998bf4fc.hot-update.js:1
```
