### PR TITLE
feat(inlining): add {esModule:'named'} option

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -213,7 +213,7 @@ export function pitch(request) {
       result = '';
       if (locals) {
         for (const key in locals) {
-          if (Object.hasOwnProperty.call(locals, key)) {
+          if (Object.prototype.hasOwnProperty.call(locals, key)) {
             if (isInvalidKey.test(key)) {
               skipped.push(key);
             } else {


### PR DESCRIPTION
This PR contains a:

- [x] new **feature**

### Motivation / Use-Case

Currently, CSS Modules usage in Webpack produces className mappings as JSON modules in bundles. Now that `css-loader` and `mini-css-extract-plugin` both support the `esModule` option, there is a way to "dissolve" these mapping modules entirely. The only required change is that className mappings must be exported as named exports rather than an object default export:

```js
// current:
export default {"a":"a_12345", "b":"b_12345"}
// revised output:
export const a = "a_12345"
export const b = "b_12345"
```

The resulting bundle improvement is ... awesome:

<table><thead><tr><th>Before:</th><th>After:</th></tr></thead>
<tbody><tr><td>

```js
[
  function(e, t, n) {
    e.exports = {
      className1: '_1QXSp-vHE2lSYKI1zPJzRj',
      className2: '_2HdeYqDJ0HpgTdR_Whcvls',
    };
  },
  function(e, t, n) {
    n.r(t);
    var r = n(0);
    document.body.insertAdjacentElement(
      'afterend',
      `<div class="${r.className1}"></div>`,
    ),
      document.body.insertAdjacentElement(
        'afterend',
        `<div class="${r.className2}"></div>`,
      );
  },
]
```

</td><td>

```js
[
  function(e, t, n) {
    n.r(t);
    document.body.insertAdjacentElement(
      'afterend',
      '<div class="_1QXSp-vHE2lSYKI1zPJzRj"></div>',
    ),
      document.body.insertAdjacentElement(
        'afterend',
        '<div class="_2HdeYqDJ0HpgTdR_Whcvls"></div>',
      );
  },
]
```

</td></tr></tbody></table>


### Breaking Changes

This isn't a breaking change, because it is only enabled when a new `"named"` value is passed for the `esModule` option.

### Additional Info

I published [constant-locals-loader](https://www.npmjs.com/package/constant-locals-loader), which performs the conversion of this loader's default exported object into named exports. The output of this PR should be the same as the result of that loader.