### PR TITLE
feat(settings): support chunkFilename as function

### DIFF
--- a/src/plugin-options.json
+++ b/src/plugin-options.json
@@ -6,7 +6,7 @@
       "type": "string"
     },
     "chunkFilename": {
-      "type": "string"
+      "anyOf": [{ "type": "string" }, { "instanceOf": "Function" }]
     },
     "moduleFilename": {
       "instanceof": "Function"

--- a/test/validate-plugin-options.test.js
+++ b/test/validate-plugin-options.test.js
@@ -7,7 +7,7 @@ describe('validate options', () => {
       failure: [true],
     },
     chunkFilename: {
-      success: ['[id].css'],
+      success: ['[id].css', () => '[id].css'],
       failure: [true],
     },
     moduleFilename: {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Lately we split our webpack build in different processes.

So `mini-css-extract-plugin` was creating chunks named `1.min.css` for different modules in each builds, overwriting the chunk from other builds. It just wasn't configured to add the hash to the name.

We configured it to add the hash to the name using the `chunkFilename` setting.

But, it named our `common.min.css` bundle as a chunk making it `common.<hash>.min.css`.

The issue is that we load this file explicitly in our templates, so we couldn't predict the new name.

A solution was to use a function for `chunkFilename`, just like webpack's configurations. But this plugin didn't support functions for this setting. 

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

Not breaking.

### Additional Info
