### PR TITLE
feat: new hook miniCssExtractPluginBeforeLinkAppend

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,9 @@ const {
   Template,
   util: { createHash },
 } = webpack;
+const {
+  SyncWaterfallHook,
+} = require("tapable");
 
 const MODULE_TYPE = 'css/mini-extract';
 
@@ -129,6 +132,8 @@ class MiniCssExtractPlugin {
 
   apply(compiler) {
     compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
+      compilation.hooks.miniCssExtractPluginBeforeLinkAppend = new SyncWaterfallHook(['source', 'chunk', 'hash'])
+
       compilation.dependencyFactories.set(
         CssDependency,
         new CssModuleFactory()
@@ -377,6 +382,7 @@ class MiniCssExtractPlugin {
                       ])
                     : '',
                   'var head = document.getElementsByTagName("head")[0];',
+                  compilation.hooks.miniCssExtractPluginBeforeLinkAppend.call('', chunk, hash),
                   'head.appendChild(linkTag);',
                 ]),
                 '}).then(function() {',


### PR DESCRIPTION
Allow the link tag to be added to the head before doing some extra processing, such as I want to set a load timeout listener

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

As the link loads, I want to add code that controls the timeout

### Breaking Changes

No

### Additional Info
