### PR TITLE
fix: support hmr in css-module (#519)

### DIFF
--- a/test/cases/hmr/expected/webpack-4/main.js
+++ b/test/cases/hmr/expected/webpack-4/main.js
@@ -89,7 +89,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 // extracted by mini-css-extract-plugin
-    if(false) { var cssReload; }
+    if(false) { var cssReload, update, varifyLocal; }
   
 
 /***/ })

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -63,6 +63,10 @@
     <p>CrossOriginLoading Option: Must be red.</p>
     <p><button>Pressing this button</button> loads chunks with crossorigin attribute and should turn green.</p>
   </div>
+  <div class="test hmr">
+    <div class="hmr-a">With CSS Module, if locals didn't change, we can hmr update style</div>
+    <div class="hmr-b">If locals changed, it will trigger a full reload of the page.</div>
+  </div>
   <div class="errors"></div>
   <script async defer src="/dist/main.js"></script>
 </body>

--- a/test/manual/src/hmr-module.js
+++ b/test/manual/src/hmr-module.js
@@ -3,6 +3,7 @@ import style from './hmr-module.module.css';
 
 export default function hmrBootstrap() {
   // should not log again if only css changed
+  // eslint-disable-next-line
   console.log('load');
   document.querySelector('.hmr-a').classList.add(style.a);
 }

--- a/test/manual/src/hmr-module.js
+++ b/test/manual/src/hmr-module.js
@@ -1,0 +1,8 @@
+/* eslint-env browser */
+import style from './hmr-module.module.css';
+
+export default function hmrBootstrap() {
+  // should not log again if only css changed
+  console.log('load');
+  document.querySelector('.hmr-a').classList.add(style.a);
+}

--- a/test/manual/src/hmr-module.module.css
+++ b/test/manual/src/hmr-module.module.css
@@ -1,0 +1,16 @@
+:local(.a) {
+  /* change inner style can update with hmr */
+  background-color: pink;
+  height: 20px;
+}
+
+:global(.hmr-b) {
+  /* global className works fine in a css-module */
+  background-color: skyblue;
+  height: 20px;
+}
+
+/* remove or add new local module would cause full reload */
+/* :local(.c) {
+  background-color: khaki;
+} */

--- a/test/manual/src/index.js
+++ b/test/manual/src/index.js
@@ -5,6 +5,7 @@
 import './initial.css';
 import './simple.css';
 import classes from './simple.module.css';
+import hmrBootstrap from './hmr-module';
 
 console.log('___CLASSES__');
 console.log(classes);
@@ -69,3 +70,5 @@ makeButton('.crossorigin', () => {
   __webpack_public_path__ = originalPublicPath;
   return promise;
 });
+
+hmrBootstrap();


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

To have hmr to update the style in css-module if a css-module's locals didn't change.

### Breaking Changes

Did not break any previous functionality.

### Additional Info

I'm not sure whether to call this pr a bug fix or a new feature, but since this repo announce that it support css-module, I think it's might better to call it a bugfix?
