### PR TITLE
feat: add hook for customizing injected runtime tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13033,8 +13033,7 @@
     "tapable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-      "dev": true
+      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
     "term-size": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "loader-utils": "^1.1.0",
     "normalize-url": "1.9.1",
     "schema-utils": "^1.0.0",
+    "tapable": "^1.1.3",
     "webpack-sources": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This contribution includes a hook that can be used to customize the attributes link tags for lazy loaded CSS chunks, and was inspired by #40. As stated in this issue, the new functionality allow plugins such as [webpack-subresource-integrity](https://github.com/waysact/webpack-subresource-integrity) to work properly with injected tags.

Example usage from an external plugin would look something like this:
```js
var MiniCssExtractPlugin = require("mini-css-extract-plugin");

const compiler; // Replace with Webpack compiler instance
const cssHooks = MiniCssExtractPlugin.getCompilerHooks(compiler);
if (cssHooks) {
  cssHooks.customize.tap('MyPlugin', (source) => source + "\n" + "linkTag.integrity = myIntegrityMap[chunkId];");
}
```

### Breaking Changes

None.

### Additional Info

The added functionality is very simple, and gives a greater freedom to other plugins wishing to utilize this functionality. However, this also means that this contribution is quite small. Please let me know if there is anything that can be improved and I will do my best to implement changes in a timely manner.