### PR TITLE
fix: module.resource is not available for css files #534

### DIFF
--- a/src/CssModule.js
+++ b/src/CssModule.js
@@ -33,6 +33,7 @@ class CssModule extends webpack.Module {
       assetsInfo,
     };
     this.buildMeta = {};
+    this.resource = this.nameForCondition();
   }
 
   // no source() so webpack 4 doesn't do add stuff to the bundle

--- a/test/cases/module-resource/a.css
+++ b/test/cases/module-resource/a.css
@@ -1,0 +1,3 @@
+p {
+  background: red;
+}

--- a/test/cases/module-resource/b.css
+++ b/test/cases/module-resource/b.css
@@ -1,0 +1,3 @@
+body {
+  background: red;
+}

--- a/test/cases/module-resource/expected/main.css
+++ b/test/cases/module-resource/expected/main.css
@@ -1,0 +1,4 @@
+body {
+  background: red;
+}
+

--- a/test/cases/module-resource/expected/vendor.css
+++ b/test/cases/module-resource/expected/vendor.css
@@ -1,0 +1,4 @@
+p {
+  background: red;
+}
+

--- a/test/cases/module-resource/index.js
+++ b/test/cases/module-resource/index.js
@@ -1,0 +1,2 @@
+import './a.css';
+import './b.css';

--- a/test/cases/module-resource/webpack.config.js
+++ b/test/cases/module-resource/webpack.config.js
@@ -1,0 +1,31 @@
+import Self from '../../../src';
+
+module.exports = {
+  entry: './index.js',
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [Self.loader, 'css-loader'],
+      },
+    ],
+  },
+  plugins: [new Self()],
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendor: {
+          name: 'vendor',
+          chunks: 'all',
+          enforce: true,
+          test: (module) => {
+            if (module.resource && module.resource.endsWith('a.css')) {
+              return true;
+            }
+            return false;
+          },
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
### Motivation / Use-Case

https://github.com/webpack-contrib/mini-css-extract-plugin/issues/534

### Breaking Changes

no

### Additional Info
