### PR TITLE
refactor: upgrade schema-utils

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -55,7 +55,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # css-loader doesn't support node@6
         node-version: [8.x, 10.x, 12.x, 14.x]
         webpack-version: [latest, next]
         exclude:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1594,8 +1594,7 @@
     "@types/json-schema": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
-      "dev": true
+      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -1843,6 +1842,17 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
         }
       }
     },
@@ -1948,7 +1958,8 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.4.1",
@@ -12068,13 +12079,13 @@
       "dev": true
     },
     "schema-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+      "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
       "requires": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
+        "@types/json-schema": "^7.0.4",
+        "ajv": "^6.12.2",
+        "ajv-keywords": "^3.4.1"
       }
     },
     "select-hose": {
@@ -13400,6 +13411,19 @@
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
         "worker-farm": "^1.7.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
       }
     },
     "test-exclude": {
@@ -14265,6 +14289,17 @@
             "esrecurse": "^4.1.0",
             "estraverse": "^4.1.1"
           }
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
         }
       }
     },
@@ -14524,6 +14559,17 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
         },
         "semver": {
           "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "dist/cjs.js",
   "engines": {
-    "node": ">= 6.9.0"
+    "node": ">= 8.9.0"
   },
   "scripts": {
     "start": "npm run build -- -w",
@@ -45,7 +45,7 @@
   "dependencies": {
     "loader-utils": "^1.1.0",
     "normalize-url": "1.9.1",
-    "schema-utils": "^1.0.0",
+    "schema-utils": "^2.7.0",
     "webpack-sources": "^1.1.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ class CssModuleFactory {
 
 class MiniCssExtractPlugin {
   constructor(options = {}) {
-    validateOptions(schema, options, 'Mini CSS Extract Plugin');
+    validateOptions(schema, options, { name: 'Mini CSS Extract Plugin' });
 
     this.options = Object.assign(
       {

--- a/src/loader.js
+++ b/src/loader.js
@@ -60,7 +60,7 @@ function findModuleById(modules, id) {
 export function pitch(request) {
   const options = loaderUtils.getOptions(this) || {};
 
-  validateOptions(schema, options, 'Mini CSS Extract Plugin Loader');
+  validateOptions(schema, options, { name: 'Mini CSS Extract Plugin Loader' });
 
   const loaders = this.loaders.slice(this.loaderIndex + 1);
 

--- a/test/__snapshots__/validate-loader-options.test.js.snap
+++ b/test/__snapshots__/validate-loader-options.test.js.snap
@@ -1,31 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`validate options should throw an error on the "esModule" option with "1" value 1`] = `
-"Mini CSS Extract Plugin Loader Invalid Options
-
-options.esModule should be boolean
-"
+"Invalid configuration object. Mini CSS Extract Plugin Loader has been initialized using a configuration object that does not match the API schema.
+ - configuration.esModule should be a boolean."
 `;
 
 exports[`validate options should throw an error on the "hmr" option with "1" value 1`] = `
-"Mini CSS Extract Plugin Loader Invalid Options
-
-options.hmr should be boolean
-"
+"Invalid configuration object. Mini CSS Extract Plugin Loader has been initialized using a configuration object that does not match the API schema.
+ - configuration.hmr should be a boolean."
 `;
 
 exports[`validate options should throw an error on the "publicPath" option with "true" value 1`] = `
-"Mini CSS Extract Plugin Loader Invalid Options
-
-options.publicPath should be string
-options.publicPath should pass \\"instanceof\\" keyword validation
-options.publicPath should match some schema in anyOf
-"
+"Invalid configuration object. Mini CSS Extract Plugin Loader has been initialized using a configuration object that does not match the API schema.
+ - configuration.publicPath should be one of these:
+   string | function
+   Details:
+    * configuration.publicPath should be a string.
+    * configuration.publicPath should be an instance of function."
 `;
 
 exports[`validate options should throw an error on the "reloadAll" option with "1" value 1`] = `
-"Mini CSS Extract Plugin Loader Invalid Options
-
-options.reloadAll should be boolean
-"
+"Invalid configuration object. Mini CSS Extract Plugin Loader has been initialized using a configuration object that does not match the API schema.
+ - configuration.reloadAll should be a boolean."
 `;

--- a/test/__snapshots__/validate-plugin-options.test.js.snap
+++ b/test/__snapshots__/validate-plugin-options.test.js.snap
@@ -1,29 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`validate options should throw an error on the "chunkFilename" option with "true" value 1`] = `
-"Mini CSS Extract Plugin Invalid Options
-
-options.chunkFilename should be string
-"
+"Invalid configuration object. Mini CSS Extract Plugin has been initialized using a configuration object that does not match the API schema.
+ - configuration.chunkFilename should be a string."
 `;
 
 exports[`validate options should throw an error on the "filename" option with "true" value 1`] = `
-"Mini CSS Extract Plugin Invalid Options
-
-options.filename should be string
-"
+"Invalid configuration object. Mini CSS Extract Plugin has been initialized using a configuration object that does not match the API schema.
+ - configuration.filename should be a string."
 `;
 
 exports[`validate options should throw an error on the "ignoreOrder" option with "1" value 1`] = `
-"Mini CSS Extract Plugin Invalid Options
-
-options.ignoreOrder should be boolean
-"
+"Invalid configuration object. Mini CSS Extract Plugin has been initialized using a configuration object that does not match the API schema.
+ - configuration.ignoreOrder should be a boolean."
 `;
 
 exports[`validate options should throw an error on the "moduleFilename" option with "true" value 1`] = `
-"Mini CSS Extract Plugin Invalid Options
-
-options.moduleFilename should pass \\"instanceof\\" keyword validation
-"
+"Invalid configuration object. Mini CSS Extract Plugin has been initialized using a configuration object that does not match the API schema.
+ - configuration.moduleFilename should be an instance of function."
 `;


### PR DESCRIPTION
Bumped node version and fixed api change.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This is the last old schema-utils in my node_modules (well, except webpack one)

### Breaking Changes

Yes, node version bumped