### PR TITLE
fix: fix Cannot find module 'mini-css-extract-plugin/src/CssDependency'

### DIFF
--- a/src/CssDependency.js
+++ b/src/CssDependency.js
@@ -41,7 +41,7 @@ class CssDependency extends webpack.Dependency {
 if (webpack.util && webpack.util.serialization) {
   webpack.util.serialization.register(
     CssDependency,
-    'mini-css-extract-plugin/src/CssDependency',
+    'mini-css-extract-plugin/dist/CssDependency',
     null,
     {
       serialize(instance, context) {

--- a/src/CssModule.js
+++ b/src/CssModule.js
@@ -96,7 +96,7 @@ class CssModule extends webpack.Module {
 if (webpack.util && webpack.util.serialization) {
   webpack.util.serialization.register(
     CssModule,
-    'mini-css-extract-plugin/src/CssModule',
+    'mini-css-extract-plugin/dist/CssModule',
     null,
     {
       serialize(instance, context) {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
