### PR TITLE
feat: support for multiple inlined stylesheets in the same style tag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -348,6 +348,12 @@ class MiniCssExtractPlugin {
                     'var tag = existingStyleTags[i];',
                     'var dataHref = tag.getAttribute("data-href");',
                     'if(dataHref === href || dataHref === fullhref) return resolve();',
+                    'if(dataHref) {',
+                    Template.indent([
+                      "var hrefs = dataHref.split(',');",
+                      'if (hrefs.indexOf(href) !== -1 || hrefs.indexOf(fullhref) !== -1) return resolve();',
+                    ]),
+                    '}',
                   ]),
                   '}',
                   'var linkTag = document.createElement("link");',


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

I have multiple CSS chunks in my web application and in some cases I want to inline more than one of these chunks into a single <style> tag.

Currently `data-href` does only support one href so I would have to create one style tag per chunk that is inlined which is not super convenient in my current stack.

```
<style data-href="/static/test.css,static/test2.css">
```

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
