### PR TITLE
fix: Cannot read property 'getModulePostOrderIndex' of undefined when only modify css  hot reload mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -428,7 +428,7 @@ class MiniCssExtractPlugin {
         ? 'getModulePostOrderIndex'
         : 'getModuleIndex2';
 
-    if (typeof chunkGroup[moduleIndexFunctionName] === 'function') {
+    if (chunkGroup && typeof chunkGroup[moduleIndexFunctionName] === 'function') {
       // Store dependencies for modules
       const moduleDependencies = new Map(modules.map((m) => [m, new Set()]));
       const moduleDependenciesReasons = new Map(


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

```bash
- git clone git@github.com:easy-team/awesome.git
- git checkout webpack5
- cd boilerplate/react
- yarn
- npm run dev
```

**modify `src/router/component/home.css` file, trigger webpack hot reload,  will follow error:**

```
<e>     at done (/Users/sky/dev/easyteam/awesome/boilerplate/react/node_modules/neo-async/async.js:2865:11)
<e>     at /Users/sky/dev/easyteam/awesome/boilerplate/react/node_modules/neo-async/async.js:2818:7
<e> -- inner error --
<e> TypeError: Cannot read property 'getModulePostOrderIndex' of undefined
<e>     at MiniCssExtractPlugin.renderContentAsset (/Users/sky/dev/easyteam/awesome/boilerplate/react/node_modules/mini-css-extract-plugin/dist/index.js:300:26)
<e>     at Object.render (/Users/sky/dev/easyteam/awesome/boilerplate/react/node_modules/mini-css-extract-plugin/dist/index.js:141:34)
<e>     at /Users/sky/dev/easyteam/awesome/boilerplate/react/node_modules/webpack/lib/HotModuleReplacementPlugin.js:504:31
<e>     at Hook.eval [as callAsync] (eval at create (/Users/sky/dev/easyteam/awesome/boilerplate/react/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:14:1)
<e>     at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/Users/sky/dev/easyteam/awesome/boilerplate/react/node_modules/webpack/node_modules/tapable/lib/Hook.js:18:14)
<e>     at cont (/Users/sky/dev/easyteam/awesome/boilerplate/react/node_modules/webpack/lib/Compilation.js:1979:33)
<e>     at /Users/sky/dev/easyteam/awesome/boilerplate/react/node_modules/webpack/lib/Compilation.js:2025:9
<e>     at /Users/sky/dev/easyteam/awesome/boilerplate/react/node_modules/neo-async/async.js:2830:7
<e>     at Object.each (/Users/sky/dev/easyteam/awesome/boilerplate/react/node_modules/neo-async/async.js:2850:39)
<e>     at Compilation.createChunkAssets (/Users/sky/dev/easyteam/awesome/boilerplate/react/node_modules/webpack/lib/Compilation.js:3037:12)
```

Debug:

when only modify css hot reload mode, the `chunk.groupsIterable.size  is 0`,  the  `chunkGroup` is undefined, will  appear 
 the `Cannot read property 'getModulePostOrderIndex' of undefined` error.