### PR TITLE
feat(webpack-5): opt-in to transitive only side effects

### DIFF
--- a/src/CssDependency.js
+++ b/src/CssDependency.js
@@ -20,6 +20,11 @@ class CssDependency extends webpack.Dependency {
     return `css-module-${this.identifier}-${this.identifierIndex}`;
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  getModuleEvaluationSideEffectsState() {
+    return webpack.ModuleGraphConnection.TRANSITIVE_ONLY;
+  }
+
   serialize(context) {
     const { write } = context;
 

--- a/test/TestCases.test.js
+++ b/test/TestCases.test.js
@@ -47,19 +47,23 @@ function compareDirectory(actual, expected) {
       const content = fs.readFileSync(path.resolve(expected, file), 'utf8');
       let actualContent;
 
-      try {
-        actualContent = fs.readFileSync(path.resolve(actual, file), 'utf8');
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log(error);
+      if (/^MISSING/.test(content)) {
+        expect(fs.existsSync(path.resolve(actual, file))).toBe(false);
+      } else {
+        try {
+          actualContent = fs.readFileSync(path.resolve(actual, file), 'utf8');
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.log(error);
 
-        const dir = fs.readdirSync(actual);
+          const dir = fs.readdirSync(actual);
 
-        // eslint-disable-next-line no-console
-        console.log({ [actual]: dir });
+          // eslint-disable-next-line no-console
+          console.log({ [actual]: dir });
+        }
+
+        expect(actualContent).toEqual(content);
       }
-
-      expect(actualContent).toEqual(content);
     }
   }
 }
@@ -117,6 +121,10 @@ describe('TestCases', () => {
         webpack(webpackConfig, (err, stats) => {
           if (err) {
             done(err);
+            return;
+          }
+          if (stats.hasErrors()) {
+            done(new Error(stats.toString()));
             return;
           }
 

--- a/test/cases/dependOn-multiple-files-per-entry/expected/webpack-5/common.js
+++ b/test/cases/dependOn-multiple-files-per-entry/expected/webpack-5/common.js
@@ -1,37 +1,20 @@
 /******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
 /******/ 	var __webpack_modules__ = ([
 /* 0 */
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
-"use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _styleC_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(1);
-/* harmony import */ var _styleC_css__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_styleC_css__WEBPACK_IMPORTED_MODULE_0__);
 
 
 
 /***/ }),
 /* 1 */
-/***/ (() => {
-
-// extracted by mini-css-extract-plugin
-
-/***/ }),
-/* 2 */
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
-"use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _styleD_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3);
-/* harmony import */ var _styleD_css__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_styleD_css__WEBPACK_IMPORTED_MODULE_0__);
 
 
-
-/***/ }),
-/* 3 */
-/***/ (() => {
-
-// extracted by mini-css-extract-plugin
 
 /***/ })
 /******/ 	]);
@@ -63,30 +46,6 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 	__webpack_require__.m = __webpack_modules__;
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat get default export */
-/******/ 	(() => {
-/******/ 		// getDefaultExport function for compatibility with non-harmony modules
-/******/ 		__webpack_require__.n = (module) => {
-/******/ 			var getter = module && module.__esModule ?
-/******/ 				() => module['default'] :
-/******/ 				() => module;
-/******/ 			__webpack_require__.d(getter, { a: getter });
-/******/ 			return getter;
-/******/ 		};
-/******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/define property getters */
-/******/ 	(() => {
-/******/ 		// define getter functions for harmony exports
-/******/ 		__webpack_require__.d = (exports, definition) => {
-/******/ 			for(var key in definition) {
-/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-/******/ 				}
-/******/ 			}
-/******/ 		};
-/******/ 	})();
-/******/ 	
 /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
 /******/ 	(() => {
 /******/ 		__webpack_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
@@ -116,7 +75,7 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 		
 /******/ 		var deferredModules = [
 /******/ 			[0],
-/******/ 			[2]
+/******/ 			[1]
 /******/ 		];
 /******/ 		// no chunk on demand loading
 /******/ 		

--- a/test/cases/dependOn-multiple-files-per-entry/expected/webpack-5/entry1.js
+++ b/test/cases/dependOn-multiple-files-per-entry/expected/webpack-5/entry1.js
@@ -1,41 +1,23 @@
 (self["webpackChunk"] = self["webpackChunk"] || []).push([[1],[
 /* 0 */,
 /* 1 */,
-/* 2 */,
-/* 3 */,
-/* 4 */
+/* 2 */
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _styleB_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(5);
-/* harmony import */ var _styleB_css__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_styleB_css__WEBPACK_IMPORTED_MODULE_0__);
 
 
 
 /***/ }),
-/* 5 */
-/***/ (() => {
-
-// extracted by mini-css-extract-plugin
-
-/***/ }),
-/* 6 */
+/* 3 */
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _styleA_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(7);
-/* harmony import */ var _styleA_css__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_styleA_css__WEBPACK_IMPORTED_MODULE_0__);
 
 
-
-/***/ }),
-/* 7 */
-/***/ (() => {
-
-// extracted by mini-css-extract-plugin
 
 /***/ })
 ],
-0,[[6,0],[4,0]]]);
+0,[[3,0],[2,0]]]);

--- a/test/cases/dependOn/expected/webpack-5/common.js
+++ b/test/cases/dependOn/expected/webpack-5/common.js
@@ -1,20 +1,12 @@
 /******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
 /******/ 	var __webpack_modules__ = ([
 /* 0 */
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
-"use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _styleB_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(1);
-/* harmony import */ var _styleB_css__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_styleB_css__WEBPACK_IMPORTED_MODULE_0__);
 
 
-
-/***/ }),
-/* 1 */
-/***/ (() => {
-
-// extracted by mini-css-extract-plugin
 
 /***/ })
 /******/ 	]);
@@ -46,30 +38,6 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 	__webpack_require__.m = __webpack_modules__;
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat get default export */
-/******/ 	(() => {
-/******/ 		// getDefaultExport function for compatibility with non-harmony modules
-/******/ 		__webpack_require__.n = (module) => {
-/******/ 			var getter = module && module.__esModule ?
-/******/ 				() => module['default'] :
-/******/ 				() => module;
-/******/ 			__webpack_require__.d(getter, { a: getter });
-/******/ 			return getter;
-/******/ 		};
-/******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/define property getters */
-/******/ 	(() => {
-/******/ 		// define getter functions for harmony exports
-/******/ 		__webpack_require__.d = (exports, definition) => {
-/******/ 			for(var key in definition) {
-/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-/******/ 				}
-/******/ 			}
-/******/ 		};
-/******/ 	})();
-/******/ 	
 /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
 /******/ 	(() => {
 /******/ 		__webpack_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)

--- a/test/cases/dependOn/expected/webpack-5/entry1.js
+++ b/test/cases/dependOn/expected/webpack-5/entry1.js
@@ -1,22 +1,13 @@
 (self["webpackChunk"] = self["webpackChunk"] || []).push([[1],[
 /* 0 */,
-/* 1 */,
-/* 2 */
+/* 1 */
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _styleA_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3);
-/* harmony import */ var _styleA_css__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_styleA_css__WEBPACK_IMPORTED_MODULE_0__);
 
 
-
-/***/ }),
-/* 3 */
-/***/ (() => {
-
-// extracted by mini-css-extract-plugin
 
 /***/ })
 ],
-0,[[2,0]]]);
+0,[[1,0]]]);

--- a/test/cases/es-module-concatenation-modules/a.css
+++ b/test/cases/es-module-concatenation-modules/a.css
@@ -1,0 +1,3 @@
+.a {
+  background: red;
+}

--- a/test/cases/es-module-concatenation-modules/b.css
+++ b/test/cases/es-module-concatenation-modules/b.css
@@ -1,0 +1,3 @@
+.b {
+  background: green;
+}

--- a/test/cases/es-module-concatenation-modules/c.css
+++ b/test/cases/es-module-concatenation-modules/c.css
@@ -1,0 +1,3 @@
+.c {
+  background: blue;
+}

--- a/test/cases/es-module-concatenation-modules/expected/webpack-4/main.css
+++ b/test/cases/es-module-concatenation-modules/expected/webpack-4/main.css
@@ -1,0 +1,12 @@
+.foo__a {
+  background: red;
+}
+
+.foo__b {
+  background: green;
+}
+
+.foo__c {
+  background: blue;
+}
+

--- a/test/cases/es-module-concatenation-modules/expected/webpack-4/main.js
+++ b/test/cases/es-module-concatenation-modules/expected/webpack-4/main.js
@@ -1,0 +1,141 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+// ESM COMPAT FLAG
+__webpack_require__.r(__webpack_exports__);
+
+// EXPORTS
+__webpack_require__.d(__webpack_exports__, "c", function() { return /* reexport */ c; });
+__webpack_require__.d(__webpack_exports__, "a", function() { return /* reexport */ a_namespaceObject; });
+__webpack_require__.d(__webpack_exports__, "b", function() { return /* reexport */ b_namespaceObject; });
+
+// NAMESPACE OBJECT: ./a.css
+var a_namespaceObject = {};
+__webpack_require__.r(a_namespaceObject);
+__webpack_require__.d(a_namespaceObject, "a", function() { return a; });
+
+// NAMESPACE OBJECT: ./b.css
+var b_namespaceObject = {};
+__webpack_require__.r(b_namespaceObject);
+__webpack_require__.d(b_namespaceObject, "b", function() { return b; });
+
+// NAMESPACE OBJECT: ./index.js
+var index_namespaceObject = {};
+__webpack_require__.r(index_namespaceObject);
+__webpack_require__.d(index_namespaceObject, "c", function() { return c; });
+__webpack_require__.d(index_namespaceObject, "a", function() { return a_namespaceObject; });
+__webpack_require__.d(index_namespaceObject, "b", function() { return b_namespaceObject; });
+
+// CONCATENATED MODULE: ./a.css
+// extracted by mini-css-extract-plugin
+const a = "foo__a";
+// CONCATENATED MODULE: ./b.css
+// extracted by mini-css-extract-plugin
+const b = "foo__b";
+// CONCATENATED MODULE: ./c.css
+// extracted by mini-css-extract-plugin
+const c = "foo__c";
+// CONCATENATED MODULE: ./index.js
+/* eslint-disable import/no-namespace */
+
+
+
+
+
+
+
+
+// eslint-disable-next-line no-console
+console.log(index_namespaceObject);
+
+
+/***/ })
+/******/ ]);

--- a/test/cases/es-module-concatenation-modules/expected/webpack-5/main.css
+++ b/test/cases/es-module-concatenation-modules/expected/webpack-5/main.css
@@ -1,0 +1,12 @@
+.foo__a {
+  background: red;
+}
+
+.foo__b {
+  background: green;
+}
+
+.foo__c {
+  background: blue;
+}
+

--- a/test/cases/es-module-concatenation-modules/expected/webpack-5/main.js
+++ b/test/cases/es-module-concatenation-modules/expected/webpack-5/main.js
@@ -4,10 +4,60 @@
 /* 0 */
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
+// ESM COMPAT FLAG
 __webpack_require__.r(__webpack_exports__);
 
+// EXPORTS
+__webpack_require__.d(__webpack_exports__, {
+  "a": () => /* reexport */ a_namespaceObject,
+  "b": () => /* reexport */ b_namespaceObject,
+  "c": () => /* reexport */ c
+});
+
+// NAMESPACE OBJECT: ./a.css
+var a_namespaceObject = {};
+__webpack_require__.r(a_namespaceObject);
+__webpack_require__.d(a_namespaceObject, {
+  "a": () => a
+});
+
+// NAMESPACE OBJECT: ./b.css
+var b_namespaceObject = {};
+__webpack_require__.r(b_namespaceObject);
+__webpack_require__.d(b_namespaceObject, {
+  "b": () => b
+});
+
+// NAMESPACE OBJECT: ./index.js
+var index_namespaceObject = {};
+__webpack_require__.r(index_namespaceObject);
+__webpack_require__.d(index_namespaceObject, {
+  "a": () => a_namespaceObject,
+  "b": () => b_namespaceObject,
+  "c": () => c
+});
+
+// CONCATENATED MODULE: ./a.css
+// extracted by mini-css-extract-plugin
+const a = "foo__a";
+// CONCATENATED MODULE: ./b.css
+// extracted by mini-css-extract-plugin
+const b = "foo__b";
+// CONCATENATED MODULE: ./c.css
+// extracted by mini-css-extract-plugin
+const c = "foo__c";
+// CONCATENATED MODULE: ./index.js
+/* eslint-disable import/no-namespace */
 
 
+
+
+
+
+
+
+// eslint-disable-next-line no-console
+console.log(index_namespaceObject);
 
 
 /***/ })
@@ -37,6 +87,23 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	(() => {
+/******/ 		// define getter functions for harmony exports
+/******/ 		__webpack_require__.d = (exports, definition) => {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	(() => {
+/******/ 		__webpack_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
 /******/ 		// define __esModule on exports

--- a/test/cases/es-module-concatenation-modules/index.js
+++ b/test/cases/es-module-concatenation-modules/index.js
@@ -1,0 +1,11 @@
+/* eslint-disable import/no-namespace */
+import * as a from './a.css';
+import * as b from './b.css';
+
+import * as all from './index';
+
+export * from './c.css';
+export { a, b };
+
+// eslint-disable-next-line no-console
+console.log(all);

--- a/test/cases/es-module-concatenation-modules/webpack.config.js
+++ b/test/cases/es-module-concatenation-modules/webpack.config.js
@@ -1,0 +1,41 @@
+import Self from '../../../src';
+
+module.exports = {
+  entry: './index.js',
+  optimization: {
+    concatenateModules: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          {
+            loader: Self.loader,
+            options: {
+              esModule: true,
+              modules: {
+                namedExport: true,
+              },
+            },
+          },
+          {
+            loader: 'css-loader',
+            options: {
+              esModule: true,
+              modules: {
+                namedExport: true,
+                localIdentName: 'foo__[local]',
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new Self({
+      filename: '[name].css',
+    }),
+  ],
+};

--- a/test/cases/hmr/expected/webpack-5/main.js
+++ b/test/cases/hmr/expected/webpack-5/main.js
@@ -71,7 +71,7 @@
 /******/ 	
 /******/ 	/* webpack/runtime/getFullHash */
 /******/ 	(() => {
-/******/ 		__webpack_require__.h = () => "56250388fc166692d434"
+/******/ 		__webpack_require__.h = () => "94636610c5b7c4b91196"
 /******/ 	})();
 /******/ 	
 /******/ 	/* webpack/runtime/global */

--- a/test/cases/split-chunks-all/expected/webpack-5/2.js
+++ b/test/cases/split-chunks-all/expected/webpack-5/2.js
@@ -1,0 +1,1 @@
+MISSING

--- a/test/enforce-esm.test.js
+++ b/test/enforce-esm.test.js
@@ -40,7 +40,7 @@ it('should keep empty module without options.esModule', async (done) => {
   const { modules } = stats.toJson({ all: false, modules: true });
   expect(
     modules.filter((m) => m.moduleType !== 'runtime' && !m.orphan).length
-  ).toBe(isWebpack4 ? 2 : 3);
+  ).toBe(2);
   expect(source('./simple.css', stats)).toMatchInlineSnapshot(
     `"// extracted by mini-css-extract-plugin"`
   );


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

mini-css leaves empty "// extract by ..." js modules in the bundle. They are unnecessary.
webpack 5 will analyse the source code as side-effect-free, but as it contains a custom dependency (`CssDependency`), this dependency also need to opt-in into being side-effect-free. But actual it's not completely side-effect-free as it points to CssModules that need to be included in the bundle. So this PR opts in into a "transitive only" side-effects mode, which allows to drop the js module but keeps the dependencies in the bundle.

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

None

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
