### PR TITLE
fix: replace const with var to avoid strict mode errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1017,7 +1017,7 @@ class MiniCssExtractPlugin {
                           [
                             `var href = ${RuntimeGlobals.require}.miniCssF(chunkId);`,
                             `var fullhref = ${RuntimeGlobals.publicPath} + href;`,
-                            'const oldTag = findStylesheet(href, fullhref);',
+                            'var oldTag = findStylesheet(href, fullhref);',
                             'if(!oldTag) return;',
                             `promises.push(new Promise(${runtimeTemplate.basicFunction(
                               'resolve, reject',

--- a/test/cases/hmr/expected/webpack-5/main.js
+++ b/test/cases/hmr/expected/webpack-5/main.js
@@ -914,7 +914,7 @@ module.exports = function (urlString) {
 /******/ 			chunkIds.forEach((chunkId) => {
 /******/ 				var href = __webpack_require__.miniCssF(chunkId);
 /******/ 				var fullhref = __webpack_require__.p + href;
-/******/ 				const oldTag = findStylesheet(href, fullhref);
+/******/ 				var oldTag = findStylesheet(href, fullhref);
 /******/ 				if(!oldTag) return;
 /******/ 				promises.push(new Promise((resolve, reject) => {
 /******/ 					var tag = createStylesheet(chunkId, fullhref, () => {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

I'm using this plugin on an app running on some old webkit browsers (~Safari 7). After updating to webpack 5, I get  the following error when running in development mode.

```
SyntaxError: Unexpected keyword 'const'. Const declarations are not supported in strict mode.
```

All the surrounding template code is using var, this one must have been missed.

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes
None

### Additional Info
None