### PR TITLE
fix: replace const with var for named exports

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -155,7 +155,7 @@ export function pitch(request) {
       ? namedExport
         ? Object.keys(locals)
             .map(
-              (key) => `\nexport const ${key} = ${JSON.stringify(locals[key])};`
+              (key) => `\nexport var ${key} = ${JSON.stringify(locals[key])};`
             )
             .join('')
         : `\n${

--- a/test/cases/es-module-concatenation-modules/expected/webpack-4/main.js
+++ b/test/cases/es-module-concatenation-modules/expected/webpack-4/main.js
@@ -116,13 +116,13 @@ __webpack_require__.d(index_namespaceObject, "b", function() { return b_namespac
 
 // CONCATENATED MODULE: ./a.css
 // extracted by mini-css-extract-plugin
-const a = "foo__a";
+var a = "foo__a";
 // CONCATENATED MODULE: ./b.css
 // extracted by mini-css-extract-plugin
-const b = "foo__b";
+var b = "foo__b";
 // CONCATENATED MODULE: ./c.css
 // extracted by mini-css-extract-plugin
-const c = "foo__c";
+var c = "foo__c";
 // CONCATENATED MODULE: ./index.js
 /* eslint-disable import/no-namespace */
 

--- a/test/cases/es-module-concatenation-modules/expected/webpack-5-importModule/main.js
+++ b/test/cases/es-module-concatenation-modules/expected/webpack-5-importModule/main.js
@@ -69,13 +69,13 @@ __webpack_require__.d(index_namespaceObject, {
 
 ;// CONCATENATED MODULE: ./a.css
 // extracted by mini-css-extract-plugin
-const a = "foo__a";
+var a = "foo__a";
 ;// CONCATENATED MODULE: ./b.css
 // extracted by mini-css-extract-plugin
-const b = "foo__b";
+var b = "foo__b";
 ;// CONCATENATED MODULE: ./c.css
 // extracted by mini-css-extract-plugin
-const c = "foo__c";
+var c = "foo__c";
 ;// CONCATENATED MODULE: ./index.js
 /* eslint-disable import/no-namespace */
 

--- a/test/cases/es-module-concatenation-modules/expected/webpack-5/main.js
+++ b/test/cases/es-module-concatenation-modules/expected/webpack-5/main.js
@@ -69,13 +69,13 @@ __webpack_require__.d(index_namespaceObject, {
 
 ;// CONCATENATED MODULE: ./a.css
 // extracted by mini-css-extract-plugin
-const a = "foo__a";
+var a = "foo__a";
 ;// CONCATENATED MODULE: ./b.css
 // extracted by mini-css-extract-plugin
-const b = "foo__b";
+var b = "foo__b";
 ;// CONCATENATED MODULE: ./c.css
 // extracted by mini-css-extract-plugin
-const c = "foo__c";
+var c = "foo__c";
 ;// CONCATENATED MODULE: ./index.js
 /* eslint-disable import/no-namespace */
 

--- a/test/cases/es-named-export-output-module/expected/main.js
+++ b/test/cases/es-named-export-output-module/expected/main.js
@@ -11,9 +11,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */   "cClass": () => (/* binding */ cClass)
 /* harmony export */ });
 // extracted by mini-css-extract-plugin
-const aClass = "foo__style__a-class";
-const bClass = "foo__style__b__class";
-const cClass = "foo__style__cClass";
+var aClass = "foo__style__a-class";
+var bClass = "foo__style__b__class";
+var cClass = "foo__style__cClass";
 
 /***/ })
 /******/ ]);

--- a/test/cases/es-named-export/expected/webpack-4/main.js
+++ b/test/cases/es-named-export/expected/webpack-4/main.js
@@ -107,9 +107,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "bClass", function() { return bClass; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "cClass", function() { return cClass; });
 // extracted by mini-css-extract-plugin
-const aClass = "foo__style__a-class";
-const bClass = "foo__style__b__class";
-const cClass = "foo__style__cClass";
+var aClass = "foo__style__a-class";
+var bClass = "foo__style__b__class";
+var cClass = "foo__style__cClass";
 
 /***/ })
 /******/ ]);

--- a/test/cases/es-named-export/expected/webpack-5-importModule/main.js
+++ b/test/cases/es-named-export/expected/webpack-5-importModule/main.js
@@ -12,9 +12,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */   "cClass": () => (/* binding */ cClass)
 /* harmony export */ });
 // extracted by mini-css-extract-plugin
-const aClass = "foo__style__a-class";
-const bClass = "foo__style__b__class";
-const cClass = "foo__style__cClass";
+var aClass = "foo__style__a-class";
+var bClass = "foo__style__b__class";
+var cClass = "foo__style__cClass";
 
 /***/ })
 /******/ 	]);

--- a/test/cases/es-named-export/expected/webpack-5/main.js
+++ b/test/cases/es-named-export/expected/webpack-5/main.js
@@ -12,9 +12,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */   "cClass": () => (/* binding */ cClass)
 /* harmony export */ });
 // extracted by mini-css-extract-plugin
-const aClass = "foo__style__a-class";
-const bClass = "foo__style__b__class";
-const cClass = "foo__style__cClass";
+var aClass = "foo__style__a-class";
+var bClass = "foo__style__b__class";
+var cClass = "foo__style__cClass";
 
 /***/ })
 /******/ 	]);


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

same motivation as https://github.com/webpack-contrib/mini-css-extract-plugin/pull/735

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

none

### Additional Info

none