### PR TITLE
fix: check for error before using other arguments

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -349,20 +349,20 @@ export function pitch(request) {
   }
 
   childCompiler.runAsChild((error, entries, compilation) => {
-    const assets = Object.create(null);
-    const assetsInfo = new Map();
-
-    for (const asset of compilation.getAssets()) {
-      assets[asset.name] = asset.source;
-      assetsInfo.set(asset.name, asset.info);
-    }
-
     if (error) {
       return callback(error);
     }
 
     if (compilation.errors.length > 0) {
       return callback(compilation.errors[0]);
+    }
+
+    const assets = Object.create(null);
+    const assetsInfo = new Map();
+
+    for (const asset of compilation.getAssets()) {
+      assets[asset.name] = asset.source;
+      assetsInfo.set(asset.name, asset.info);
     }
 
     compilation.fileDependencies.forEach((dep) => {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
I was trying to get a Webpack build configuration to work, but I hit an error with mini-css-extract-plugin:

`TypeError: Cannot read property 'getAssets' of undefined`

The second line in the stack trace lead me to the [Compiler.js file](https://github.com/webpack/webpack/blob/ad1c80214d30676edcf83cb8f74135646ced9cc8/lib/Compiler.js#L523) in the Webpack source code where it invokes a callback and passes only an error as argument. Looking at the code in mini-css-extract-plugin, it was trivial to see what wrong: `compilation.getAssets()` doesn't work when the `compilation` argument isn't passed and equals undefined.

By moving the check for errors to earlier in the callback I could actually see the original error with my Webpack build configuration and fix it from there. With this PR I hope to prevent someone else from experiencing the same problem.