### PR TITLE
fix(hmr): hmr not work in browser extension

### DIFF
--- a/src/hmr/hotModuleReplacement.js
+++ b/src/hmr/hotModuleReplacement.js
@@ -198,8 +198,8 @@ function reloadAll() {
 function isUrlRequest(url) {
   // An URL is not an request if
 
-  // It is not http or https
-  if (!/^https?:/i.test(url)) {
+  // It is not http or https or browser extension
+  if (!/^(https?|.*extension):/i.test(url)) {
     return false;
   }
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Current `isUrlRequest` in `hotModuleReplacement` is not work in browser extension, because:

Chrome use chrome-extension://
Microsoft Edge use extension://
Firefox use moz-extension://


### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
