### PR TITLE
Clarify limitations with mini-css-extract-plugin & initial chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ module.exports = {
 };
 ```
 
+### ⚠ CSS is not loaded from initial chunks.
+
+Note that if you import CSS from your webpack entrypoint (in the initial chunk), `mini-css-extract-plugin` will not load this CSS into the page. `html-webpack-plugin` usually loads this CSS for you, but if you're not using that plugin, you'll need to use a dynamic `import()` to force the CSS to be split into a separate chunk. Either of the following would work:
+
+**component.js**
+
+```js
+import("./style.css");
+```
+
+**app.js**
+
+```js
+import("./component");
+```
+
+
 ## Options
 
 ### Plugin Options


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

My app doesn't use html-webpack-plugin, and some CSS wasn't loading when using mini-css-extract-plugin. After a lot of confusion I found that it seems that mini-css-extract-plugin doesn't support loading CSS when imported from the initial chunk.

This attempts to document the limitation, though it's entirely possible I misunderstand the core issue. Let me know if you think it could be improved or if there's any other workarounds.

### Additional Info

https://github.com/webpack-contrib/mini-css-extract-plugin/issues/760
https://github.com/webpack-contrib/mini-css-extract-plugin/issues/785