### PR TITLE
docs: fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ A new `<link>` element will be inserted before the element with id `some-element
 Type: `Object`
 Default: `{}`
 
-If defined, the `mini-css-extract-plugin` will attach given attributes with their values on <link> element.
+If defined, the `mini-css-extract-plugin` will attach given attributes with their values on `<link>` element.
 
 **webpack.config.js**
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Currently [it shows](https://github.com/webpack-contrib/mini-css-extract-plugin#attributes):

![](https://user-images.githubusercontent.com/1091472/129469959-19e72175-f84e-4c5e-8dc1-0bc8500142e2.png)

As you can see, there's no `<link>` at all.

### Breaking Changes

No.

### Additional Info
