### PR TITLE
fix: validate absolute paths in filename

### DIFF
--- a/src/plugin-options.json
+++ b/src/plugin-options.json
@@ -6,7 +6,9 @@
     "filename": {
       "anyOf": [
         {
-          "type": "string"
+          "type": "string",
+          "absolutePath": false,
+          "minLength": 1
         },
         {
           "instanceof": "Function"

--- a/test/__snapshots__/validate-plugin-options.test.js.snap
+++ b/test/__snapshots__/validate-plugin-options.test.js.snap
@@ -19,14 +19,19 @@ exports[`validate options should throw an error on the "chunkFilename" option wi
     * options.chunkFilename should be an instance of function."
 `;
 
+exports[`validate options should throw an error on the "filename" option with "/styles/[name].css" value 1`] = `
+"Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
+ - options.filename: A relative path is expected. However, the provided value \\"/styles/[name].css\\" is an absolute path!"
+`;
+
 exports[`validate options should throw an error on the "filename" option with "true" value 1`] = `
 "Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
  - options.filename should be one of these:
-   string | function
+   non-empty string | function
    -> This option determines the name of each output CSS file.
    -> Read more at https://github.com/webpack-contrib/mini-css-extract-plugin#filename
    Details:
-    * options.filename should be a string.
+    * options.filename should be a non-empty string.
     * options.filename should be an instance of function."
 `;
 

--- a/test/validate-plugin-options.test.js
+++ b/test/validate-plugin-options.test.js
@@ -7,7 +7,7 @@ describe("validate options", () => {
         "[name].css",
         ({ name }) => `${name.replace("/js/", "/css/")}.css`,
       ],
-      failure: [true],
+      failure: [true, "/styles/[name].css"],
     },
     chunkFilename: {
       success: ["[id].css", ({ chunk }) => `${chunk.id}.${chunk.name}.css`],


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
Fix https://github.com/webpack-contrib/mini-css-extract-plugin/issues/877

### Breaking Changes
No

### Additional Info
Do not allow absolute paths in filename schema, add min length of 1.