### PR TITLE
fix: do not allow absolute path in chunkFilename

### DIFF
--- a/src/plugin-options.json
+++ b/src/plugin-options.json
@@ -20,7 +20,9 @@
     "chunkFilename": {
       "anyOf": [
         {
-          "type": "string"
+          "type": "string",
+          "absolutePath": false,
+          "minLength": 1
         },
         {
           "instanceof": "Function"

--- a/test/__snapshots__/validate-plugin-options.test.js.snap
+++ b/test/__snapshots__/validate-plugin-options.test.js.snap
@@ -8,6 +8,11 @@ exports[`validate options should throw an error on the "attributes" option with 
    -> Read more at https://github.com/webpack-contrib/mini-css-extract-plugin#attributes"
 `;
 
+exports[`validate options should throw an error on the "chunkFilename" option with "" value 1`] = `
+"Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
+ - options.chunkFilename should be a non-empty string."
+`;
+
 exports[`validate options should throw an error on the "chunkFilename" option with "/styles/[id].css" value 1`] = `
 "Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
  - options.chunkFilename: A relative path is expected. However, the provided value \\"/styles/[id].css\\" is an absolute path!"
@@ -22,6 +27,11 @@ exports[`validate options should throw an error on the "chunkFilename" option wi
    Details:
     * options.chunkFilename should be a non-empty string.
     * options.chunkFilename should be an instance of function."
+`;
+
+exports[`validate options should throw an error on the "filename" option with "" value 1`] = `
+"Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
+ - options.filename should be a non-empty string."
 `;
 
 exports[`validate options should throw an error on the "filename" option with "/styles/[name].css" value 1`] = `

--- a/test/__snapshots__/validate-plugin-options.test.js.snap
+++ b/test/__snapshots__/validate-plugin-options.test.js.snap
@@ -8,14 +8,19 @@ exports[`validate options should throw an error on the "attributes" option with 
    -> Read more at https://github.com/webpack-contrib/mini-css-extract-plugin#attributes"
 `;
 
+exports[`validate options should throw an error on the "chunkFilename" option with "/styles/[id].css" value 1`] = `
+"Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
+ - options.chunkFilename: A relative path is expected. However, the provided value \\"/styles/[id].css\\" is an absolute path!"
+`;
+
 exports[`validate options should throw an error on the "chunkFilename" option with "true" value 1`] = `
 "Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
  - options.chunkFilename should be one of these:
-   string | function
+   non-empty string | function
    -> This option determines the name of non-entry chunk files.
    -> Read more at https://github.com/webpack-contrib/mini-css-extract-plugin#chunkfilename
    Details:
-    * options.chunkFilename should be a string.
+    * options.chunkFilename should be a non-empty string.
     * options.chunkFilename should be an instance of function."
 `;
 

--- a/test/validate-plugin-options.test.js
+++ b/test/validate-plugin-options.test.js
@@ -7,11 +7,11 @@ describe("validate options", () => {
         "[name].css",
         ({ name }) => `${name.replace("/js/", "/css/")}.css`,
       ],
-      failure: [true, "/styles/[name].css"],
+      failure: [true, "/styles/[name].css", ""],
     },
     chunkFilename: {
       success: ["[id].css", ({ chunk }) => `${chunk.id}.${chunk.name}.css`],
-      failure: [true, "/styles/[id].css"],
+      failure: [true, "/styles/[id].css", ""],
     },
     ignoreOrder: {
       success: [true, false],

--- a/test/validate-plugin-options.test.js
+++ b/test/validate-plugin-options.test.js
@@ -11,7 +11,7 @@ describe("validate options", () => {
     },
     chunkFilename: {
       success: ["[id].css", ({ chunk }) => `${chunk.id}.${chunk.name}.css`],
-      failure: [true],
+      failure: [true, "/styles/[id].css"],
     },
     ignoreOrder: {
       success: [true, false],


### PR DESCRIPTION
As per https://github.com/webpack-contrib/mini-css-extract-plugin/pull/878 file paths shouldn't be absolute, so update the schema for the rule

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
https://github.com/webpack-contrib/mini-css-extract-plugin/pull/878

### Breaking Changes
no

### Additional Info
