### PR TITLE
fix: expand lint-staged, use eslint cache

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  "*.js": ["eslint --fix", "prettier --write"],
-  "*.{json,md,yml,css,ts}": ["prettier --write"],
+  "*": ["prettier --write --ignore-unknown"],
+  "*.{js,ts}": ["eslint --cache --fix"],
 };


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case
Since prettier is run across the whole repo as part of the lint job, this ensures that the files get run by the commit hook

### Breaking Changes
no

### Additional Info
