### PR TITLE
fix: [2.5.1] mark getCssModule and getCssDependency as public

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
       "devDependencies": {
         "@babel/cli": "^7.16.7",
         "@babel/core": "^7.16.7",
-        "@babel/eslint-parser": "^7.16.0",
+        "@babel/eslint-parser": "^7.16.5",
         "@babel/preset-env": "^7.16.7",
-        "@commitlint/cli": "^15.0.0",
-        "@commitlint/config-conventional": "^15.0.0",
+        "@commitlint/cli": "^16.0.2",
+        "@commitlint/config-conventional": "^16.0.0",
         "@webpack-contrib/eslint-config-webpack": "^3.0.0",
         "babel-jest": "^27.0.6",
         "bootstrap": "^4.6.0",
@@ -25,18 +25,18 @@
         "css-loader": "^6.2.0",
         "del": "^6.0.0",
         "del-cli": "^4.0.0",
-        "es-check": "^6.0.0",
-        "eslint": "^8.6.0",
-        "eslint-config-prettier": "^8.1.0",
+        "es-check": "^6.1.1",
+        "eslint": "^8.7.0",
+        "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.25.4",
         "file-loader": "^6.2.0",
         "husky": "^7.0.0",
         "jest": "^27.0.6",
         "jsdom": "^19.0.0",
-        "lint-staged": "^12.1.5",
+        "lint-staged": "^12.1.7",
         "memfs": "^3.4.1",
         "npm-run-all": "^4.1.5",
-        "prettier": "^2.3.2",
+        "prettier": "^2.5.1",
         "sass": "^1.45.2",
         "sass-loader": "^12.1.0",
         "standard-version": "^9.3.0",
@@ -1808,16 +1808,16 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-15.0.0.tgz",
-      "integrity": "sha512-Y5xmDCweytqzo4N4lOI2YRiuX35xTjcs8n5hUceBH8eyK0YbwtgWX50BJOH2XbkwEmII9blNhlBog6AdQsqicg==",
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-16.0.2.tgz",
+      "integrity": "sha512-Jt7iaBjoLGC5Nq4dHPTvTYnqPGkElFPBtTXTvBpTgatZApczyjI2plE0oG4GYWPp1suHIS/VdVDOMpPZjGVusg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/format": "^15.0.0",
-        "@commitlint/lint": "^15.0.0",
-        "@commitlint/load": "^15.0.0",
-        "@commitlint/read": "^15.0.0",
-        "@commitlint/types": "^15.0.0",
+        "@commitlint/format": "^16.0.0",
+        "@commitlint/lint": "^16.0.0",
+        "@commitlint/load": "^16.0.0",
+        "@commitlint/read": "^16.0.0",
+        "@commitlint/types": "^16.0.0",
         "lodash": "^4.17.19",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0",
@@ -1831,9 +1831,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-15.0.0.tgz",
-      "integrity": "sha512-eZBRL8Lk3hMNHp1wUMYj0qrZQEsST1ai7KHR8J1IDD9aHgT7L2giciibuQ+Og7vxVhR5WtYDvh9xirXFVPaSkQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-16.0.0.tgz",
+      "integrity": "sha512-mN7J8KlKFn0kROd+q9PB01sfDx/8K/R25yITspL1No8PB4oj9M1p77xWjP80hPydqZG9OvQq+anXK3ZWeR7s3g==",
       "dev": true,
       "dependencies": {
         "conventional-changelog-conventionalcommits": "^4.3.1"
@@ -1842,13 +1842,26 @@
         "node": ">=v12"
       }
     },
-    "node_modules/@commitlint/ensure": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-15.0.0.tgz",
-      "integrity": "sha512-7DV4iNIald3vycwaWBNGk5FbonaNzOlU8nBe5m5AgU2dIeNKuXwLm+zzJzG27j0Ho56rgz//3F6RIvmsoxY9ZA==",
+    "node_modules/@commitlint/config-validator": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-16.0.0.tgz",
+      "integrity": "sha512-i80DGlo1FeC5jZpuoNV9NIjQN/m2dDV3jYGWg+1Wr+KldptkUHXj+6GY1Akll66lJ3D8s6aUGi3comPLHPtWHg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^15.0.0",
+        "@commitlint/types": "^16.0.0",
+        "ajv": "^6.12.6"
+      },
+      "engines": {
+        "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/ensure": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-16.0.0.tgz",
+      "integrity": "sha512-WdMySU8DCTaq3JPf0tZFCKIUhqxaL54mjduNhu8v4D2AMUVIIQKYMGyvXn94k8begeW6iJkTf9cXBArayskE7Q==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/types": "^16.0.0",
         "lodash": "^4.17.19"
       },
       "engines": {
@@ -1856,21 +1869,21 @@
       }
     },
     "node_modules/@commitlint/execute-rule": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-15.0.0.tgz",
-      "integrity": "sha512-pyE4ApxjbWhb1TXz5vRiGwI2ssdMMgZbaaheZq1/7WC0xRnqnIhE1yUC1D2q20qPtvkZPstTYvMiRVtF+DvjUg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-16.0.0.tgz",
+      "integrity": "sha512-8edcCibmBb386x5JTHSPHINwA5L0xPkHQFY8TAuDEt5QyRZY/o5DF8OPHSa5Hx2xJvGaxxuIz4UtAT6IiRDYkw==",
       "dev": true,
       "engines": {
         "node": ">=v12"
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-15.0.0.tgz",
-      "integrity": "sha512-bPhAfqwRhPk92WiuY0ktEJNpRRHSCd+Eg1MdhGyL9Bl3U25E5zvuInA+dNctnzZiOBSH/37ZaD0eOKCpQE6acg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-16.0.0.tgz",
+      "integrity": "sha512-9yp5NCquXL1jVMKL0ZkRwJf/UHdebvCcMvICuZV00NQGYSAL89O398nhqrqxlbjBhM5EZVq0VGcV5+7r3D4zAA==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^15.0.0",
+        "@commitlint/types": "^16.0.0",
         "chalk": "^4.0.0"
       },
       "engines": {
@@ -1948,12 +1961,12 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-15.0.0.tgz",
-      "integrity": "sha512-edtnkf2QZ/7e/YCJDgn1WDw9wfF1WfOitW5YEoSOb4SxjJEb/oE87kxNPZ2j8mnDMuunspcMfGHeg6fRlwaEWg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-16.0.0.tgz",
+      "integrity": "sha512-gmAQcwIGC/R/Lp0CEb2b5bfGC7MT5rPe09N8kOGjO/NcdNmfFSZMquwrvNJsq9hnAP0skRdHIsqwlkENkN4Lag==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^15.0.0",
+        "@commitlint/types": "^16.0.0",
         "semver": "7.3.5"
       },
       "engines": {
@@ -1976,32 +1989,33 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-15.0.0.tgz",
-      "integrity": "sha512-hUi2+Im/2dJ5FBvWnodypTkg+5haCgsDzB0fyMApWLUA1IucYUAqRCQCW5em1Mhk9Crw1pd5YzFNikhIclkqCw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-16.0.0.tgz",
+      "integrity": "sha512-HNl15bRC0h+pLzbMzQC3tM0j1aESXsLYhElqKnXcf5mnCBkBkHzu6WwJW8rZbfxX+YwJmNljN62cPhmdBo8x0A==",
       "dev": true,
       "dependencies": {
-        "@commitlint/is-ignored": "^15.0.0",
-        "@commitlint/parse": "^15.0.0",
-        "@commitlint/rules": "^15.0.0",
-        "@commitlint/types": "^15.0.0"
+        "@commitlint/is-ignored": "^16.0.0",
+        "@commitlint/parse": "^16.0.0",
+        "@commitlint/rules": "^16.0.0",
+        "@commitlint/types": "^16.0.0"
       },
       "engines": {
         "node": ">=v12"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-15.0.0.tgz",
-      "integrity": "sha512-Ak1YPeOhvxmY3ioe0o6m1yLGvUAYb4BdfGgShU8jiTCmU3Mnmms0Xh/kfQz8AybhezCC3AmVTyBLaBZxOHR8kg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-16.0.0.tgz",
+      "integrity": "sha512-7WhrGCkP6K/XfjBBguLkkI2XUdiiIyMGlNsSoSqgRNiD352EiffhFEApMy1/XOU+viwBBm/On0n5p0NC7e9/4A==",
       "dev": true,
       "dependencies": {
-        "@commitlint/execute-rule": "^15.0.0",
-        "@commitlint/resolve-extends": "^15.0.0",
-        "@commitlint/types": "^15.0.0",
-        "@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
+        "@commitlint/config-validator": "^16.0.0",
+        "@commitlint/execute-rule": "^16.0.0",
+        "@commitlint/resolve-extends": "^16.0.0",
+        "@commitlint/types": "^16.0.0",
         "chalk": "^4.0.0",
         "cosmiconfig": "^7.0.0",
+        "cosmiconfig-typescript-loader": "^1.0.0",
         "lodash": "^4.17.19",
         "resolve-from": "^5.0.0",
         "typescript": "^4.4.3"
@@ -2081,21 +2095,21 @@
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-15.0.0.tgz",
-      "integrity": "sha512-L8euabzboKavPuDJsdIYAY2wx97LbiGEYsckMo6NmV8pOun50c8hQx6ouXFSAx4pp+mX9yUGmMiVqfrk2LKDJQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-16.0.0.tgz",
+      "integrity": "sha512-CmK2074SH1Ws6kFMEKOKH/7hMekGVbOD6vb4alCOo2+33ZSLUIX8iNkDYyrw38Jwg6yWUhLjyQLUxREeV+QIUA==",
       "dev": true,
       "engines": {
         "node": ">=v12"
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-15.0.0.tgz",
-      "integrity": "sha512-7fweM67tZfBNS7zw1KTuuT5K2u9nGytUJqFqT/1Ln3Na9cBCsoAqR47mfsNOTlRCgGwakm4xiQ7BpS2gN0OGuw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-16.0.0.tgz",
+      "integrity": "sha512-F9EjFlMw4MYgBEqoRrWZZKQBzdiJzPBI0qFDFqwUvfQsMmXEREZ242T4R5bFwLINWaALFLHEIa/FXEPa6QxCag==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^15.0.0",
+        "@commitlint/types": "^16.0.0",
         "conventional-changelog-angular": "^5.0.11",
         "conventional-commits-parser": "^3.2.2"
       },
@@ -2104,13 +2118,13 @@
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-15.0.0.tgz",
-      "integrity": "sha512-5yI1o2HKZFVe7RTjL7IhuhHMKar/MDNY34vEHqqz9gMI7BK/rdP8uVb4Di1efl2V0UPnwID0nPKWESjQ8Ti0gw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-16.0.0.tgz",
+      "integrity": "sha512-H4T2zsfmYQK9B+JtoQaCXWBHUhgIJyOzWZjSfuIV9Ce69/OgHoffNpLZPF2lX6yKuDrS1SQFhI/kUCjVc/e4ew==",
       "dev": true,
       "dependencies": {
-        "@commitlint/top-level": "^15.0.0",
-        "@commitlint/types": "^15.0.0",
+        "@commitlint/top-level": "^16.0.0",
+        "@commitlint/types": "^16.0.0",
         "fs-extra": "^10.0.0",
         "git-raw-commits": "^2.0.0"
       },
@@ -2119,11 +2133,13 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-15.0.0.tgz",
-      "integrity": "sha512-7apfRJjgJsKja7lHsPfEFixKjA/fk/UeD3owkOw1174yYu4u8xBDLSeU3IinGPdMuF9m245eX8wo7vLUy+EBSg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-16.0.0.tgz",
+      "integrity": "sha512-Z/w9MAQUcxeawpCLtjmkVNXAXOmB2nhW+LYmHEZcx9O6UTauF/1+uuZ2/r0MtzTe1qw2JD+1QHVhEWYHVPlkdA==",
       "dev": true,
       "dependencies": {
+        "@commitlint/config-validator": "^16.0.0",
+        "@commitlint/types": "^16.0.0",
         "import-fresh": "^3.0.0",
         "lodash": "^4.17.19",
         "resolve-from": "^5.0.0",
@@ -2134,15 +2150,15 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-15.0.0.tgz",
-      "integrity": "sha512-SqXfp6QUlwBS+0IZm4FEA/NmmAwcFQIkG3B05BtemOVWXQdZ8j1vV6hDwvA9oMPCmUSrrGpHOtZK7HaHhng2yA==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-16.0.0.tgz",
+      "integrity": "sha512-AOl0y2SBTdJ1bvIv8nwHvQKRT/jC1xb09C5VZwzHoT8sE8F54KDeEzPCwHQFgUcWdGLyS10kkOTAH2MyA8EIlg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/ensure": "^15.0.0",
-        "@commitlint/message": "^15.0.0",
-        "@commitlint/to-lines": "^15.0.0",
-        "@commitlint/types": "^15.0.0",
+        "@commitlint/ensure": "^16.0.0",
+        "@commitlint/message": "^16.0.0",
+        "@commitlint/to-lines": "^16.0.0",
+        "@commitlint/types": "^16.0.0",
         "execa": "^5.0.0"
       },
       "engines": {
@@ -2150,18 +2166,18 @@
       }
     },
     "node_modules/@commitlint/to-lines": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-15.0.0.tgz",
-      "integrity": "sha512-mY3MNA9ujPqVpiJjTYG9MDsYCobue5PJFO0MfcIzS1mCVvngH8ZFTPAh1fT5t+t1h876boS88+9WgqjRvbYItw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-16.0.0.tgz",
+      "integrity": "sha512-iN/qU38TCKU7uKOg6RXLpD49wNiuI0TqMqybHbjefUeP/Jmzxa8ishryj0uLyVdrAl1ZjGeD1ukXGMTtvqz8iA==",
       "dev": true,
       "engines": {
         "node": ">=v12"
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-15.0.0.tgz",
-      "integrity": "sha512-7Gz3t7xcuuUw1d1Nou6YLaztzp2Em+qZ6YdCzrqYc+aquca3Vt0O696nuiBDU/oE+tls4Hx2CNpAbWhTgEwB5A==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-16.0.0.tgz",
+      "integrity": "sha512-/Jt6NLxyFkpjL5O0jxurZPCHURZAm7cQCqikgPCwqPAH0TLgwqdHjnYipl8J+AGnAMGDip4FNLoYrtgIpZGBYw==",
       "dev": true,
       "dependencies": {
         "find-up": "^5.0.0"
@@ -2171,9 +2187,9 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-15.0.0.tgz",
-      "integrity": "sha512-OMSLX+QJnyNoTwws54ULv9sOvuw9GdVezln76oyUd4YbMMJyaav62aSXDuCdWyL2sm9hTkSzyEi52PNaIj/vqw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-+0FvYOAS39bJ4aKjnYn/7FD4DfWkmQ6G/06I4F0Gvu4KS5twirEg8mIcLhmeRDOOKn4Tp8PwpLwBiSA6npEMQA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0"
@@ -2252,6 +2268,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
@@ -2259,24 +2296,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz",
-      "integrity": "sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==",
-      "dev": true,
-      "dependencies": {
-        "lodash.get": "^4",
-        "make-error": "^1",
-        "ts-node": "^9",
-        "tslib": "^2"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "cosmiconfig": ">=6"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -3172,6 +3191,30 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.18",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.18.tgz",
@@ -3891,6 +3934,8 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5370,6 +5415,25 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.3.tgz",
+      "integrity": "sha512-ARo21VjxdacJUcHxgVMEYNIoVPYiuKOEwWBIYej4M22+pEbe3LzKgmht2UPM+0u7/T/KnZf2r/5IzHv2Nwz+/w==",
+      "dev": true,
+      "dependencies": {
+        "cosmiconfig": "^7",
+        "ts-node": "^10.4.0"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=7",
+        "typescript": ">=3"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -6180,6 +6244,8 @@
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1"
       },
@@ -6411,9 +6477,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.6.0.tgz",
-      "integrity": "sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
+      "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.0.5",
@@ -6423,11 +6489,10 @@
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
-        "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.0",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.1.0",
+        "eslint-visitor-keys": "^3.2.0",
         "espree": "^9.3.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
@@ -6436,7 +6501,7 @@
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.6.0",
-        "ignore": "^4.0.6",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
@@ -6447,9 +6512,7 @@
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "progress": "^2.0.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.2.1",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0",
@@ -6760,9 +6823,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
+      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6813,6 +6876,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/eslint/node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -6823,21 +6895,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/eslint/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint/node_modules/supports-color": {
@@ -11449,12 +11506,6 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
-    },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -12711,15 +12762,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
-    },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -14733,29 +14775,53 @@
       "dev": true
     },
     "node_modules/ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
       "dev": true,
       "dependencies": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
         "yn": "3.1.1"
       },
       "bin": {
         "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
         "ts-node-script": "dist/bin-script.js",
         "ts-node-transpile-only": "dist/bin-transpile.js",
         "ts-script": "dist/bin-script-deprecated.js"
       },
-      "engines": {
-        "node": ">=10.0.0"
-      },
       "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
         "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -16989,16 +17055,16 @@
       }
     },
     "@commitlint/cli": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-15.0.0.tgz",
-      "integrity": "sha512-Y5xmDCweytqzo4N4lOI2YRiuX35xTjcs8n5hUceBH8eyK0YbwtgWX50BJOH2XbkwEmII9blNhlBog6AdQsqicg==",
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-16.0.2.tgz",
+      "integrity": "sha512-Jt7iaBjoLGC5Nq4dHPTvTYnqPGkElFPBtTXTvBpTgatZApczyjI2plE0oG4GYWPp1suHIS/VdVDOMpPZjGVusg==",
       "dev": true,
       "requires": {
-        "@commitlint/format": "^15.0.0",
-        "@commitlint/lint": "^15.0.0",
-        "@commitlint/load": "^15.0.0",
-        "@commitlint/read": "^15.0.0",
-        "@commitlint/types": "^15.0.0",
+        "@commitlint/format": "^16.0.0",
+        "@commitlint/lint": "^16.0.0",
+        "@commitlint/load": "^16.0.0",
+        "@commitlint/read": "^16.0.0",
+        "@commitlint/types": "^16.0.0",
         "lodash": "^4.17.19",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0",
@@ -17006,37 +17072,47 @@
       }
     },
     "@commitlint/config-conventional": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-15.0.0.tgz",
-      "integrity": "sha512-eZBRL8Lk3hMNHp1wUMYj0qrZQEsST1ai7KHR8J1IDD9aHgT7L2giciibuQ+Og7vxVhR5WtYDvh9xirXFVPaSkQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-16.0.0.tgz",
+      "integrity": "sha512-mN7J8KlKFn0kROd+q9PB01sfDx/8K/R25yITspL1No8PB4oj9M1p77xWjP80hPydqZG9OvQq+anXK3ZWeR7s3g==",
       "dev": true,
       "requires": {
         "conventional-changelog-conventionalcommits": "^4.3.1"
       }
     },
-    "@commitlint/ensure": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-15.0.0.tgz",
-      "integrity": "sha512-7DV4iNIald3vycwaWBNGk5FbonaNzOlU8nBe5m5AgU2dIeNKuXwLm+zzJzG27j0Ho56rgz//3F6RIvmsoxY9ZA==",
+    "@commitlint/config-validator": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-16.0.0.tgz",
+      "integrity": "sha512-i80DGlo1FeC5jZpuoNV9NIjQN/m2dDV3jYGWg+1Wr+KldptkUHXj+6GY1Akll66lJ3D8s6aUGi3comPLHPtWHg==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^15.0.0",
+        "@commitlint/types": "^16.0.0",
+        "ajv": "^6.12.6"
+      }
+    },
+    "@commitlint/ensure": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-16.0.0.tgz",
+      "integrity": "sha512-WdMySU8DCTaq3JPf0tZFCKIUhqxaL54mjduNhu8v4D2AMUVIIQKYMGyvXn94k8begeW6iJkTf9cXBArayskE7Q==",
+      "dev": true,
+      "requires": {
+        "@commitlint/types": "^16.0.0",
         "lodash": "^4.17.19"
       }
     },
     "@commitlint/execute-rule": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-15.0.0.tgz",
-      "integrity": "sha512-pyE4ApxjbWhb1TXz5vRiGwI2ssdMMgZbaaheZq1/7WC0xRnqnIhE1yUC1D2q20qPtvkZPstTYvMiRVtF+DvjUg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-16.0.0.tgz",
+      "integrity": "sha512-8edcCibmBb386x5JTHSPHINwA5L0xPkHQFY8TAuDEt5QyRZY/o5DF8OPHSa5Hx2xJvGaxxuIz4UtAT6IiRDYkw==",
       "dev": true
     },
     "@commitlint/format": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-15.0.0.tgz",
-      "integrity": "sha512-bPhAfqwRhPk92WiuY0ktEJNpRRHSCd+Eg1MdhGyL9Bl3U25E5zvuInA+dNctnzZiOBSH/37ZaD0eOKCpQE6acg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-16.0.0.tgz",
+      "integrity": "sha512-9yp5NCquXL1jVMKL0ZkRwJf/UHdebvCcMvICuZV00NQGYSAL89O398nhqrqxlbjBhM5EZVq0VGcV5+7r3D4zAA==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^15.0.0",
+        "@commitlint/types": "^16.0.0",
         "chalk": "^4.0.0"
       },
       "dependencies": {
@@ -17092,12 +17168,12 @@
       }
     },
     "@commitlint/is-ignored": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-15.0.0.tgz",
-      "integrity": "sha512-edtnkf2QZ/7e/YCJDgn1WDw9wfF1WfOitW5YEoSOb4SxjJEb/oE87kxNPZ2j8mnDMuunspcMfGHeg6fRlwaEWg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-16.0.0.tgz",
+      "integrity": "sha512-gmAQcwIGC/R/Lp0CEb2b5bfGC7MT5rPe09N8kOGjO/NcdNmfFSZMquwrvNJsq9hnAP0skRdHIsqwlkENkN4Lag==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^15.0.0",
+        "@commitlint/types": "^16.0.0",
         "semver": "7.3.5"
       },
       "dependencies": {
@@ -17113,29 +17189,30 @@
       }
     },
     "@commitlint/lint": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-15.0.0.tgz",
-      "integrity": "sha512-hUi2+Im/2dJ5FBvWnodypTkg+5haCgsDzB0fyMApWLUA1IucYUAqRCQCW5em1Mhk9Crw1pd5YzFNikhIclkqCw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-16.0.0.tgz",
+      "integrity": "sha512-HNl15bRC0h+pLzbMzQC3tM0j1aESXsLYhElqKnXcf5mnCBkBkHzu6WwJW8rZbfxX+YwJmNljN62cPhmdBo8x0A==",
       "dev": true,
       "requires": {
-        "@commitlint/is-ignored": "^15.0.0",
-        "@commitlint/parse": "^15.0.0",
-        "@commitlint/rules": "^15.0.0",
-        "@commitlint/types": "^15.0.0"
+        "@commitlint/is-ignored": "^16.0.0",
+        "@commitlint/parse": "^16.0.0",
+        "@commitlint/rules": "^16.0.0",
+        "@commitlint/types": "^16.0.0"
       }
     },
     "@commitlint/load": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-15.0.0.tgz",
-      "integrity": "sha512-Ak1YPeOhvxmY3ioe0o6m1yLGvUAYb4BdfGgShU8jiTCmU3Mnmms0Xh/kfQz8AybhezCC3AmVTyBLaBZxOHR8kg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-16.0.0.tgz",
+      "integrity": "sha512-7WhrGCkP6K/XfjBBguLkkI2XUdiiIyMGlNsSoSqgRNiD352EiffhFEApMy1/XOU+viwBBm/On0n5p0NC7e9/4A==",
       "dev": true,
       "requires": {
-        "@commitlint/execute-rule": "^15.0.0",
-        "@commitlint/resolve-extends": "^15.0.0",
-        "@commitlint/types": "^15.0.0",
-        "@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
+        "@commitlint/config-validator": "^16.0.0",
+        "@commitlint/execute-rule": "^16.0.0",
+        "@commitlint/resolve-extends": "^16.0.0",
+        "@commitlint/types": "^16.0.0",
         "chalk": "^4.0.0",
         "cosmiconfig": "^7.0.0",
+        "cosmiconfig-typescript-loader": "^1.0.0",
         "lodash": "^4.17.19",
         "resolve-from": "^5.0.0",
         "typescript": "^4.4.3"
@@ -17193,40 +17270,42 @@
       }
     },
     "@commitlint/message": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-15.0.0.tgz",
-      "integrity": "sha512-L8euabzboKavPuDJsdIYAY2wx97LbiGEYsckMo6NmV8pOun50c8hQx6ouXFSAx4pp+mX9yUGmMiVqfrk2LKDJQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-16.0.0.tgz",
+      "integrity": "sha512-CmK2074SH1Ws6kFMEKOKH/7hMekGVbOD6vb4alCOo2+33ZSLUIX8iNkDYyrw38Jwg6yWUhLjyQLUxREeV+QIUA==",
       "dev": true
     },
     "@commitlint/parse": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-15.0.0.tgz",
-      "integrity": "sha512-7fweM67tZfBNS7zw1KTuuT5K2u9nGytUJqFqT/1Ln3Na9cBCsoAqR47mfsNOTlRCgGwakm4xiQ7BpS2gN0OGuw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-16.0.0.tgz",
+      "integrity": "sha512-F9EjFlMw4MYgBEqoRrWZZKQBzdiJzPBI0qFDFqwUvfQsMmXEREZ242T4R5bFwLINWaALFLHEIa/FXEPa6QxCag==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^15.0.0",
+        "@commitlint/types": "^16.0.0",
         "conventional-changelog-angular": "^5.0.11",
         "conventional-commits-parser": "^3.2.2"
       }
     },
     "@commitlint/read": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-15.0.0.tgz",
-      "integrity": "sha512-5yI1o2HKZFVe7RTjL7IhuhHMKar/MDNY34vEHqqz9gMI7BK/rdP8uVb4Di1efl2V0UPnwID0nPKWESjQ8Ti0gw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-16.0.0.tgz",
+      "integrity": "sha512-H4T2zsfmYQK9B+JtoQaCXWBHUhgIJyOzWZjSfuIV9Ce69/OgHoffNpLZPF2lX6yKuDrS1SQFhI/kUCjVc/e4ew==",
       "dev": true,
       "requires": {
-        "@commitlint/top-level": "^15.0.0",
-        "@commitlint/types": "^15.0.0",
+        "@commitlint/top-level": "^16.0.0",
+        "@commitlint/types": "^16.0.0",
         "fs-extra": "^10.0.0",
         "git-raw-commits": "^2.0.0"
       }
     },
     "@commitlint/resolve-extends": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-15.0.0.tgz",
-      "integrity": "sha512-7apfRJjgJsKja7lHsPfEFixKjA/fk/UeD3owkOw1174yYu4u8xBDLSeU3IinGPdMuF9m245eX8wo7vLUy+EBSg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-16.0.0.tgz",
+      "integrity": "sha512-Z/w9MAQUcxeawpCLtjmkVNXAXOmB2nhW+LYmHEZcx9O6UTauF/1+uuZ2/r0MtzTe1qw2JD+1QHVhEWYHVPlkdA==",
       "dev": true,
       "requires": {
+        "@commitlint/config-validator": "^16.0.0",
+        "@commitlint/types": "^16.0.0",
         "import-fresh": "^3.0.0",
         "lodash": "^4.17.19",
         "resolve-from": "^5.0.0",
@@ -17234,37 +17313,37 @@
       }
     },
     "@commitlint/rules": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-15.0.0.tgz",
-      "integrity": "sha512-SqXfp6QUlwBS+0IZm4FEA/NmmAwcFQIkG3B05BtemOVWXQdZ8j1vV6hDwvA9oMPCmUSrrGpHOtZK7HaHhng2yA==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-16.0.0.tgz",
+      "integrity": "sha512-AOl0y2SBTdJ1bvIv8nwHvQKRT/jC1xb09C5VZwzHoT8sE8F54KDeEzPCwHQFgUcWdGLyS10kkOTAH2MyA8EIlg==",
       "dev": true,
       "requires": {
-        "@commitlint/ensure": "^15.0.0",
-        "@commitlint/message": "^15.0.0",
-        "@commitlint/to-lines": "^15.0.0",
-        "@commitlint/types": "^15.0.0",
+        "@commitlint/ensure": "^16.0.0",
+        "@commitlint/message": "^16.0.0",
+        "@commitlint/to-lines": "^16.0.0",
+        "@commitlint/types": "^16.0.0",
         "execa": "^5.0.0"
       }
     },
     "@commitlint/to-lines": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-15.0.0.tgz",
-      "integrity": "sha512-mY3MNA9ujPqVpiJjTYG9MDsYCobue5PJFO0MfcIzS1mCVvngH8ZFTPAh1fT5t+t1h876boS88+9WgqjRvbYItw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-16.0.0.tgz",
+      "integrity": "sha512-iN/qU38TCKU7uKOg6RXLpD49wNiuI0TqMqybHbjefUeP/Jmzxa8ishryj0uLyVdrAl1ZjGeD1ukXGMTtvqz8iA==",
       "dev": true
     },
     "@commitlint/top-level": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-15.0.0.tgz",
-      "integrity": "sha512-7Gz3t7xcuuUw1d1Nou6YLaztzp2Em+qZ6YdCzrqYc+aquca3Vt0O696nuiBDU/oE+tls4Hx2CNpAbWhTgEwB5A==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-16.0.0.tgz",
+      "integrity": "sha512-/Jt6NLxyFkpjL5O0jxurZPCHURZAm7cQCqikgPCwqPAH0TLgwqdHjnYipl8J+AGnAMGDip4FNLoYrtgIpZGBYw==",
       "dev": true,
       "requires": {
         "find-up": "^5.0.0"
       }
     },
     "@commitlint/types": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-15.0.0.tgz",
-      "integrity": "sha512-OMSLX+QJnyNoTwws54ULv9sOvuw9GdVezln76oyUd4YbMMJyaav62aSXDuCdWyL2sm9hTkSzyEi52PNaIj/vqw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-+0FvYOAS39bJ4aKjnYn/7FD4DfWkmQ6G/06I4F0Gvu4KS5twirEg8mIcLhmeRDOOKn4Tp8PwpLwBiSA6npEMQA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0"
@@ -17321,23 +17400,26 @@
         }
       }
     },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
       "integrity": "sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==",
       "dev": true
-    },
-    "@endemolshinegroup/cosmiconfig-typescript-loader": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz",
-      "integrity": "sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==",
-      "dev": true,
-      "requires": {
-        "lodash.get": "^4",
-        "make-error": "^1",
-        "ts-node": "^9",
-        "tslib": "^2"
-      }
     },
     "@eslint/eslintrc": {
       "version": "1.0.5",
@@ -18016,6 +18098,30 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true
     },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.18",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.18.tgz",
@@ -18674,7 +18780,9 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -19829,6 +19937,16 @@
         "yaml": "^1.10.0"
       }
     },
+    "cosmiconfig-typescript-loader": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.3.tgz",
+      "integrity": "sha512-ARo21VjxdacJUcHxgVMEYNIoVPYiuKOEwWBIYej4M22+pEbe3LzKgmht2UPM+0u7/T/KnZf2r/5IzHv2Nwz+/w==",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^7",
+        "ts-node": "^10.4.0"
+      }
+    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -20416,6 +20534,8 @@
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "ansi-colors": "^4.1.1"
       }
@@ -20589,9 +20709,9 @@
       }
     },
     "eslint": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.6.0.tgz",
-      "integrity": "sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
+      "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.0.5",
@@ -20601,11 +20721,10 @@
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
-        "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.0",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.1.0",
+        "eslint-visitor-keys": "^3.2.0",
         "espree": "^9.3.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
@@ -20614,7 +20733,7 @@
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.6.0",
-        "ignore": "^4.0.6",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
@@ -20625,9 +20744,7 @@
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "progress": "^2.0.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.2.1",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0",
@@ -20691,9 +20808,9 @@
           }
         },
         "eslint-visitor-keys": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-          "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
+          "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
           "dev": true
         },
         "estraverse": {
@@ -20726,6 +20843,12 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
+        },
         "js-yaml": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -20733,15 +20856,6 @@
           "dev": true,
           "requires": {
             "argparse": "^2.0.1"
-          }
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
           }
         },
         "supports-color": {
@@ -24358,12 +24472,6 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
-    },
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -25286,12 +25394,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
-    "progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "prompts": {
@@ -26827,17 +26929,31 @@
       "dev": true
     },
     "ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
       "dev": true,
       "requires": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
         "yn": "3.1.1"
+      },
+      "dependencies": {
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "dev": true
+        }
       }
     },
     "tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   },
   "files": [
     "dist",
-    "types"
+    "types",
+    "public.d.ts"
   ],
   "peerDependencies": {
     "webpack": "^5.0.0"
@@ -53,10 +54,10 @@
   "devDependencies": {
     "@babel/cli": "^7.16.7",
     "@babel/core": "^7.16.7",
-    "@babel/eslint-parser": "^7.16.0",
+    "@babel/eslint-parser": "^7.16.5",
     "@babel/preset-env": "^7.16.7",
-    "@commitlint/cli": "^15.0.0",
-    "@commitlint/config-conventional": "^15.0.0",
+    "@commitlint/cli": "^16.0.2",
+    "@commitlint/config-conventional": "^16.0.0",
     "@webpack-contrib/eslint-config-webpack": "^3.0.0",
     "babel-jest": "^27.0.6",
     "bootstrap": "^4.6.0",
@@ -64,18 +65,18 @@
     "css-loader": "^6.2.0",
     "del": "^6.0.0",
     "del-cli": "^4.0.0",
-    "es-check": "^6.0.0",
-    "eslint": "^8.6.0",
-    "eslint-config-prettier": "^8.1.0",
+    "es-check": "^6.1.1",
+    "eslint": "^8.7.0",
+    "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.25.4",
     "file-loader": "^6.2.0",
     "husky": "^7.0.0",
     "jest": "^27.0.6",
     "jsdom": "^19.0.0",
-    "lint-staged": "^12.1.5",
+    "lint-staged": "^12.1.7",
     "memfs": "^3.4.1",
     "npm-run-all": "^4.1.5",
-    "prettier": "^2.3.2",
+    "prettier": "^2.5.1",
     "sass": "^1.45.2",
     "sass-loader": "^12.1.0",
     "standard-version": "^9.3.0",

--- a/public.d.ts
+++ b/public.d.ts
@@ -1,0 +1,57 @@
+type Module = import("webpack").Module;
+type Dependency = import("webpack").Dependency;
+type Source = import("webpack").sources.Source;
+type AssetInfo = import("webpack").AssetInfo;
+
+export interface CssModule {
+  new ({
+    context,
+    identifier,
+    identifierIndex,
+    content,
+    layer,
+    supports,
+    media,
+    sourceMap,
+    assets,
+    assetsInfo,
+  }: {
+    context: string;
+    identifier: string;
+    identifierIndex: number;
+    content: Buffer;
+    layer: string | null;
+    supports?: string;
+    media: string;
+    sourceMap?: Buffer;
+    assets: { [key: string]: Source };
+    assetsInfo: Map<string, AssetInfo>;
+  }): Module;
+}
+
+interface CssDependencyPublicOptions {
+  identifier: string;
+  content: Buffer;
+  layer?: string;
+  supports?: string;
+  media: string;
+  sourceMap?: Buffer;
+}
+
+export interface CssDependency {
+  new (
+    {
+      identifier,
+      content,
+      layer,
+      supports,
+      media,
+      sourceMap,
+    }: CssDependencyPublicOptions,
+    context: string | null,
+    identifierIndex: number
+  ): Dependency & {
+    assetsInfo?: Map<string, AssetInfo>;
+    assets?: { [key: string]: Source };
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ const registered = new WeakSet();
 
 class MiniCssExtractPlugin {
   /**
-   * @private
+   * @public
    * @param {Compiler["webpack"]} webpack
    * @returns {typeof CssModule}
    */
@@ -346,7 +346,7 @@ class MiniCssExtractPlugin {
   }
 
   /**
-   * @private
+   * @public
    * @param {Compiler["webpack"]} webpack
    * @returns {typeof CssDependency}
    */

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ class MiniCssExtractPlugin {
   /**
    * @public
    * @param {Compiler["webpack"]} webpack
-   * @returns {typeof CssModule}
+   * @returns {import("../public").CssModule}
    */
   static getCssModule(webpack) {
     /**
@@ -348,7 +348,7 @@ class MiniCssExtractPlugin {
   /**
    * @public
    * @param {Compiler["webpack"]} webpack
-   * @returns {typeof CssDependency}
+   * @returns {import("../public").CssDependency}
    */
   static getCssDependency(webpack) {
     /**

--- a/src/loader.js
+++ b/src/loader.js
@@ -126,12 +126,11 @@ function pitch(request) {
           identifierCountMap.get(
             /** @type {Dependency} */ (dependency).identifier
           ) || 0;
-        // @ts-ignore
+
         const CssDependency = MiniCssExtractPlugin.getCssDependency(webpack);
 
         /** @type {NormalModule} */
         (this._module).addDependency(
-          // @ts-ignore
           (lastDep = new CssDependency(
             /** @type {Dependency} */
             (dependency),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true
   },
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*", "public.d.ts"]
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,13 +1,13 @@
 export = MiniCssExtractPlugin;
 declare class MiniCssExtractPlugin {
   /**
-   * @private
+   * @public
    * @param {Compiler["webpack"]} webpack
    * @returns {typeof CssModule}
    */
   private static getCssModule;
   /**
-   * @private
+   * @public
    * @param {Compiler["webpack"]} webpack
    * @returns {typeof CssDependency}
    */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,15 +3,19 @@ declare class MiniCssExtractPlugin {
   /**
    * @public
    * @param {Compiler["webpack"]} webpack
-   * @returns {typeof CssModule}
+   * @returns {import("../public").CssModule}
    */
-  private static getCssModule;
+  public static getCssModule(
+    webpack: Compiler["webpack"]
+  ): import("../public").CssModule;
   /**
    * @public
    * @param {Compiler["webpack"]} webpack
-   * @returns {typeof CssDependency}
+   * @returns {import("../public").CssDependency}
    */
-  private static getCssDependency;
+  public static getCssDependency(
+    webpack: Compiler["webpack"]
+  ): import("../public").CssDependency;
   /**
    * @param {PluginOptions} [options]
    */


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Mark `getCssModule` and `getCssDependency` as public 
`getCssModule` is the base of our integration to `mini-css-extract-plugin` added support done here #703 
We ended up not using `getCssDependency` but I feel like it should also be public.
These are the basic building blocks for proper integration to css bundling in webpack

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes
Fix types
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
