### PR TITLE
feat: support named exports with any characters

### DIFF
--- a/test/cases/custom-loader-with-functional-exports/expected/main.js
+++ b/test/cases/custom-loader-with-functional-exports/expected/main.js
@@ -7,12 +7,14 @@
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   cnA: () => (/* binding */ cnA),
-/* harmony export */   cnB: () => (/* binding */ cnB)
+/* harmony export */   cnA: () => (/* binding */ _1),
+/* harmony export */   cnB: () => (/* binding */ _2)
 /* harmony export */ });
 // extracted by mini-css-extract-plugin
-var cnA = () => "class-name-a";
-var cnB = () => "class-name-b";
+var _1 = () => "class-name-a";
+var _2 = () => "class-name-b";;
+
+
 
 /***/ })
 /******/ 	]);

--- a/test/cases/es-module-concatenation-modules/expected/main.js
+++ b/test/cases/es-module-concatenation-modules/expected/main.js
@@ -41,21 +41,21 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: () => (/* reexport */ a_namespaceObject),
   b: () => (/* reexport */ b_namespaceObject),
-  c: () => (/* reexport */ c)
+  c: () => (/* reexport */ c_1)
 });
 
 // NAMESPACE OBJECT: ./a.css
 var a_namespaceObject = {};
 __webpack_require__.r(a_namespaceObject);
 __webpack_require__.d(a_namespaceObject, {
-  a: () => (a)
+  a: () => (_1)
 });
 
 // NAMESPACE OBJECT: ./b.css
 var b_namespaceObject = {};
 __webpack_require__.r(b_namespaceObject);
 __webpack_require__.d(b_namespaceObject, {
-  b: () => (b)
+  b: () => (b_1)
 });
 
 // NAMESPACE OBJECT: ./index.js
@@ -64,18 +64,24 @@ __webpack_require__.r(index_namespaceObject);
 __webpack_require__.d(index_namespaceObject, {
   a: () => (a_namespaceObject),
   b: () => (b_namespaceObject),
-  c: () => (c)
+  c: () => (c_1)
 });
 
 ;// CONCATENATED MODULE: ./a.css
 // extracted by mini-css-extract-plugin
-var a = "foo__a";
+var _1 = "foo__a";;
+
+
 ;// CONCATENATED MODULE: ./b.css
 // extracted by mini-css-extract-plugin
-var b = "foo__b";
+var b_1 = "foo__b";;
+
+
 ;// CONCATENATED MODULE: ./c.css
 // extracted by mini-css-extract-plugin
-var c = "foo__c";
+var c_1 = "foo__c";;
+
+
 ;// CONCATENATED MODULE: ./index.js
 /* eslint-disable import/no-namespace */
 

--- a/test/cases/es-named-export-output-module/expected/main.mjs
+++ b/test/cases/es-named-export-output-module/expected/main.mjs
@@ -5,14 +5,16 @@
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   aClass: () => (/* binding */ aClass),
-/* harmony export */   bClass: () => (/* binding */ bClass),
-/* harmony export */   cClass: () => (/* binding */ cClass)
+/* harmony export */   aClass: () => (/* binding */ _1),
+/* harmony export */   bClass: () => (/* binding */ _2),
+/* harmony export */   cClass: () => (/* binding */ _3)
 /* harmony export */ });
 // extracted by mini-css-extract-plugin
-var aClass = "foo__style__a-class";
-var bClass = "foo__style__b__class";
-var cClass = "foo__style__cClass";
+var _1 = "foo__style__a-class";
+var _2 = "foo__style__b__class";
+var _3 = "foo__style__cClass";;
+
+
 
 /***/ })
 /******/ ]);

--- a/test/cases/es-named-export/expected/main.js
+++ b/test/cases/es-named-export/expected/main.js
@@ -7,14 +7,16 @@
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   aClass: () => (/* binding */ aClass),
-/* harmony export */   bClass: () => (/* binding */ bClass),
-/* harmony export */   cClass: () => (/* binding */ cClass)
+/* harmony export */   aClass: () => (/* binding */ _1),
+/* harmony export */   bClass: () => (/* binding */ _2),
+/* harmony export */   cClass: () => (/* binding */ _3)
 /* harmony export */ });
 // extracted by mini-css-extract-plugin
-var aClass = "foo__style__a-class";
-var bClass = "foo__style__b__class";
-var cClass = "foo__style__cClass";
+var _1 = "foo__style__a-class";
+var _2 = "foo__style__b__class";
+var _3 = "foo__style__cClass";;
+
+
 
 /***/ })
 /******/ 	]);

--- a/test/cases/export-only-locals-and-es-named-export/expected/main.js
+++ b/test/cases/export-only-locals-and-es-named-export/expected/main.js
@@ -7,14 +7,16 @@
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   aClass: () => (/* binding */ aClass),
-/* harmony export */   bClass: () => (/* binding */ bClass),
-/* harmony export */   cClass: () => (/* binding */ cClass)
+/* harmony export */   aClass: () => (/* binding */ _1),
+/* harmony export */   bClass: () => (/* binding */ _2),
+/* harmony export */   cClass: () => (/* binding */ _3)
 /* harmony export */ });
 // extracted by mini-css-extract-plugin
-var aClass = "foo__style__a-class";
-var bClass = "foo__style__b__class";
-var cClass = "foo__style__cClass";
+var _1 = "foo__style__a-class";
+var _2 = "foo__style__b__class";
+var _3 = "foo__style__cClass";;
+
+
 
 /***/ })
 /******/ 	]);


### PR DESCRIPTION
A proposed change to `css-loader` will allow named exports to be any string, regardless of whether or not it is a valid identifier. The code generation in this project assumes that all exports will be a valid identifier, so the generation stage has been updated to take this into account.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [X] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

When using the new "asIs" named exports feature I submitted in webpack-contrib/css-loader#1549, this module will produce incorrect output since the export names may not be valid local identifiers.

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes
Requires support for `export { local as "string literal" }` syntax which is not supported until nodejs v16.x.
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
Named exports resolve the Terser bailout condition described in webpack/webpack#17626 but reduce "grepability" of your code.