### PR TITLE
fix: no template for dependency error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -650,6 +650,16 @@ class MiniCssExtractPlugin {
           };
         }
       );
+
+      class CssDependencyTemplate {
+        // eslint-disable-next-line class-methods-use-this
+        apply() {}
+      }
+
+      compilation.dependencyTemplates.set(
+        CssDependency,
+        new CssDependencyTemplate()
+      );
     });
 
     compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
@@ -671,16 +681,6 @@ class MiniCssExtractPlugin {
       compilation.dependencyFactories.set(
         CssDependency,
         new CssModuleFactory()
-      );
-
-      class CssDependencyTemplate {
-        // eslint-disable-next-line class-methods-use-this
-        apply() {}
-      }
-
-      compilation.dependencyTemplates.set(
-        CssDependency,
-        new CssDependencyTemplate()
       );
 
       compilation.hooks.renderManifest.tap(


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
An error would thrown when CSS module called in an EJS Template, like this.   
```
  ERROR in ./src/pages/style.scss
  No template for dependency: CssDependency
  Error: No template for dependency: CssDependency
      at JavascriptGenerator.sourceDependency (/home/user/data/dev/bloghaze/node_modules/webpack/lib/javascript/JavascriptGenerator.js:188:10)
      at JavascriptGenerator.sourceModule (/home/user/data/dev/bloghaze/node_modules/webpack/lib/javascript/JavascriptGenerator.js:112:9)
      at JavascriptGenerator.generate (/home/user/data/dev/bloghaze/node_modules/webpack/lib/javascript/JavascriptGenerator.js:98:8)
      at NormalModule.codeGeneration (/home/user/data/dev/bloghaze/node_modules/webpack/lib/NormalModule.js:1208:22)
      at /home/user/data/dev/bloghaze/node_modules/webpack/lib/Compilation.js:3332:22
      at /home/user/data/dev/bloghaze/node_modules/webpack/lib/Cache.js:93:5
      at Hook.eval [as callAsync] (eval at create (/home/user/data/dev/bloghaze/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
      at Cache.get (/home/user/data/dev/bloghaze/node_modules/webpack/lib/Cache.js:75:18)
      at ItemCacheFacade.get (/home/user/data/dev/bloghaze/node_modules/webpack/lib/CacheFacade.js:115:15)
      at Compilation._codeGenerationModule (/home/user/data/dev/bloghaze/node_modules/webpack/lib/Compilation.js:3325:9)
   @ ./src/pages/ sync ^\.\/.*$ ./style.scss
   @ ./node_modules/html-webpack-plugin/lib/loader.js!./src/template.ejs 17:20-48

  Child HtmlWebpackCompiler compiled with 1 error
```

After hours of debugging, I found out that `CssDependencyTemplate` is not injected to `dependencyTemplates` which assigned to the `Compilation` object for generating the code.   
I moved the injection hook from `thisCompilation` to `compilation` to apply the template to all `Compilation` objects.
### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
