### PR TITLE
fix: adding media, supports and layer for external import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1368,11 +1368,32 @@ class MiniCssExtractPlugin {
 
         // HACK for IE
         // http://stackoverflow.com/a/14676665/1458162
-        if (module.media) {
+        if (
+          module.media ||
+          module.supports ||
+          typeof module.layer !== "undefined"
+        ) {
+          let atImportExtra = "";
+
+          const needLayer = typeof module.layer !== "undefined";
+
+          if (needLayer) {
+            atImportExtra +=
+              module.layer.length > 0 ? ` layer(${module.layer})` : " layer";
+          }
+
+          if (module.supports) {
+            atImportExtra += ` supports(${module.supports})`;
+          }
+
+          if (module.media) {
+            atImportExtra += ` ${module.media}`;
+          }
+
           // insert media into the @import
           // this is rar
           // TODO improve this and parse the CSS to support multiple medias
-          content = content.replace(/;|\s*$/, `${module.media};`);
+          content = content.replace(/;|\s*$/, `${atImportExtra};`);
         }
 
         externalsSource.add(content);

--- a/test/cases/at-import-external-with-media/a.css
+++ b/test/cases/at-import-external-with-media/a.css
@@ -1,0 +1,15 @@
+@import url(http://some/path/to/css1.css);
+@import url(http://some/path/to/css2.css) screen and (max-width: 1024px);
+@import url(http://some/path/to/css3.css) supports(display: grid) screen and
+  (max-width: 400px);
+@import url(http://some/path/to/css4.css) supports(display: grid);
+@import url(http://some/path/to/css5.css) layer();
+@import url(http://some/path/to/css6.css) layer;
+@import url(http://some/path/to/css7.css) layer(layer-name)
+  supports(display: grid) screen and (max-width: 1024px);
+@import url(http://some/path/to/css8.css) layer(layer-name) screen and
+  (max-width: 1024px);
+
+body {
+  background: red;
+}

--- a/test/cases/at-import-external-with-media/b.css
+++ b/test/cases/at-import-external-with-media/b.css
@@ -1,0 +1,5 @@
+@import url("https://some/external/css");
+
+.b {
+  background: red;
+}

--- a/test/cases/at-import-external-with-media/expected/main.css
+++ b/test/cases/at-import-external-with-media/expected/main.css
@@ -1,0 +1,17 @@
+@import url(http://some/path/to/css1.css);
+@import url(http://some/path/to/css2.css) screen and (max-width: 1024px);
+@import url(http://some/path/to/css3.css) supports(display: grid) screen and (max-width: 400px);
+@import url(http://some/path/to/css4.css) supports(display: grid);
+@import url(http://some/path/to/css5.css) layer;
+@import url(http://some/path/to/css6.css) layer;
+@import url(http://some/path/to/css7.css) layer(layer-name) supports(display: grid) screen and (max-width: 1024px);
+@import url(http://some/path/to/css8.css) layer(layer-name) screen and (max-width: 1024px);
+@import url(https://some/external/css);
+body {
+  background: red;
+}
+
+.b {
+  background: red;
+}
+

--- a/test/cases/at-import-external-with-media/expected/main.css
+++ b/test/cases/at-import-external-with-media/expected/main.css
@@ -1,11 +1,13 @@
 @import url(http://some/path/to/css1.css);
 @import url(http://some/path/to/css2.css) screen and (max-width: 1024px);
-@import url(http://some/path/to/css3.css) supports(display: grid) screen and (max-width: 400px);
+@import url(http://some/path/to/css3.css) supports(display: grid) screen and
+  (max-width: 400px);
 @import url(http://some/path/to/css4.css) supports(display: grid);
 @import url(http://some/path/to/css5.css) layer;
 @import url(http://some/path/to/css6.css) layer;
 @import url(http://some/path/to/css7.css) layer(layer-name) supports(display: grid) screen and (max-width: 1024px);
-@import url(http://some/path/to/css8.css) layer(layer-name) screen and (max-width: 1024px);
+@import url(http://some/path/to/css8.css) layer(layer-name) screen and
+  (max-width: 1024px);
 @import url(https://some/external/css);
 body {
   background: red;

--- a/test/cases/at-import-external-with-media/index.js
+++ b/test/cases/at-import-external-with-media/index.js
@@ -1,0 +1,2 @@
+import "./a.css";
+import "./b.css";

--- a/test/cases/at-import-external-with-media/webpack.config.js
+++ b/test/cases/at-import-external-with-media/webpack.config.js
@@ -1,0 +1,18 @@
+import Self from "../../../src";
+
+module.exports = {
+  entry: "./index.js",
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [Self.loader, "css-loader"],
+      },
+    ],
+  },
+  plugins: [
+    new Self({
+      filename: "[name].css",
+    }),
+  ],
+};


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes https://github.com/webpack-contrib/mini-css-extract-plugin/issues/1049

### Breaking Changes

No

### Additional Info

No