### PR TITLE
fix: safer removeChild by checking parent node

### DIFF
--- a/src/hmr/hotModuleReplacement.js
+++ b/src/hmr/hotModuleReplacement.js
@@ -130,7 +130,7 @@ function updateCss(el, url) {
   newEl.isLoaded = false;
 
   newEl.addEventListener("load", () => {
-    if (newEl.isLoaded) {
+    if (newEl.isLoaded || el.parentNode === null) {
       return;
     }
 
@@ -139,7 +139,7 @@ function updateCss(el, url) {
   });
 
   newEl.addEventListener("error", () => {
-    if (newEl.isLoaded) {
+    if (newEl.isLoaded || el.parentNode === null) {
       return;
     }
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [+ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
I got fed up with nextjs throwing this error:

```
runtime Error


Error: Cannot read properties of null (reading 'removeChild')

Call Stack
1

Hide 1 ignore-listed frame(s)
HTMLLinkElement.eval
node_modules\next\dist\compiled\mini-css-extract-plugin\hmr\hotModuleReplacement.js (1:1137)
```
So I patched the minified file to check if parentNode is null (which fixed the issue) and im uploading the patch here.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
