### PR TITLE
fix: should contains GetFilenameRuntime for initial chunks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1248,7 +1248,7 @@ class MiniCssExtractPlugin {
                 ? this.options.filename
                 : this.options.chunkFilename;
             },
-            false
+            set.has(RuntimeGlobals.hmrDownloadUpdateHandlers)
           )
         );
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Initial css chunk cannot update if user specify `filename` or `chunkFilename`. Because `MiniCssExtractPlugin` has `GetChunkFilenameRuntimeModule` and force the `allChunks` parameter to be `false`, that will cause that runtime cannot get correct url for updated initial css chunk.

This change aligns behavior of webpack's native css support.

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
