### PR TITLE
fix(contentHash): Prevent generation of a contentHash for a chunk when the set of css modules is of size 0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -786,7 +786,7 @@ class MiniCssExtractPlugin {
           compilation.runtimeTemplate.requestShortener,
         );
 
-        if (modules) {
+        if (modules?.size > 0) {
           const { hashFunction, hashDigest, hashDigestLength } = outputOptions;
           const { createHash } = compiler.webpack.util;
           const hash = createHash(/** @type {string} */ (hashFunction));


### PR DESCRIPTION
**Summary**
`min-css-extract-plugin` generates contentHash's corresponding to an empty file for chunks with no css modules.
<img width="359" height="191" alt="image" src="https://github.com/user-attachments/assets/91cb27b4-52af-4336-abb6-05bd64fc8991" />
Note: `ef46db3751d8e999` is the hash of an empty file in the hash algorithm used in the example

It does this because it only checks if the set `modules` exists, but the set `modules` is just filtered for css chunks and so in the case there are no css chunks will return a set of length zero which still evaluates as true. See the code changes for more details, it should make sense, comment if it doesn't. 

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
No - happy to add if this change looks good 

**Does this PR introduce a breaking change?**
This should not introduce a breaking change, someone may have done something weird with this output though, or assume that `contentHash['css/mini-extract']` is defined. 

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
I don't believe there's any documentation required for this. 
